### PR TITLE
Drop support for EOL Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "2.6"
   - "2.7"
   - "3.4"
   - "3.5"

--- a/pydot.py
+++ b/pydot.py
@@ -30,7 +30,7 @@ else:
     str_type = basestring
 
 
-GRAPH_ATTRIBUTES = set( ['Damping', 'K', 'URL', 'aspect', 'bb', 'bgcolor',
+GRAPH_ATTRIBUTES = { 'Damping', 'K', 'URL', 'aspect', 'bb', 'bgcolor',
     'center', 'charset', 'clusterrank', 'colorscheme', 'comment', 'compound',
     'concentrate', 'defaultdist', 'dim', 'dimen', 'diredgeconstraints',
     'dpi', 'epsilon', 'esep', 'fontcolor', 'fontname', 'fontnames',
@@ -45,10 +45,10 @@ GRAPH_ATTRIBUTES = set( ['Damping', 'K', 'URL', 'aspect', 'bb', 'bgcolor',
     'showboxes', 'size', 'smoothing', 'sortv', 'splines', 'start',
     'stylesheet', 'target', 'truecolor', 'viewport', 'voro_margin',
     # for subgraphs
-    'rank' ] )
+    'rank'  }
 
 
-EDGE_ATTRIBUTES = set( ['URL', 'arrowhead', 'arrowsize', 'arrowtail',
+EDGE_ATTRIBUTES = { 'URL', 'arrowhead', 'arrowsize', 'arrowtail',
     'color', 'colorscheme', 'comment', 'constraint', 'decorate', 'dir',
     'edgeURL', 'edgehref', 'edgetarget', 'edgetooltip', 'fontcolor',
     'fontname', 'fontsize', 'headURL', 'headclip', 'headhref', 'headlabel',
@@ -59,10 +59,10 @@ EDGE_ATTRIBUTES = set( ['URL', 'arrowhead', 'arrowsize', 'arrowtail',
     'nojustify', 'penwidth', 'pos', 'samehead', 'sametail', 'showboxes',
     'style', 'tailURL', 'tailclip', 'tailhref', 'taillabel', 'tailport',
     'tailtarget', 'tailtooltip', 'target', 'tooltip', 'weight',
-    'rank' ] )
+    'rank'  }
 
 
-NODE_ATTRIBUTES = set( ['URL', 'color', 'colorscheme', 'comment',
+NODE_ATTRIBUTES = { 'URL', 'color', 'colorscheme', 'comment',
     'distortion', 'fillcolor', 'fixedsize', 'fontcolor', 'fontname',
     'fontsize', 'group', 'height', 'id', 'image', 'imagescale', 'label',
     'labelloc', 'layer', 'margin', 'nojustify', 'orientation', 'penwidth',
@@ -70,13 +70,13 @@ NODE_ATTRIBUTES = set( ['URL', 'color', 'colorscheme', 'comment',
     'shape', 'shapefile', 'showboxes', 'sides', 'skew', 'sortv', 'style',
     'target', 'tooltip', 'vertices', 'width', 'z',
     # The following are attributes dot2tex
-    'texlbl',  'texmode' ] )
+    'texlbl',  'texmode'  }
 
 
-CLUSTER_ATTRIBUTES = set( ['K', 'URL', 'bgcolor', 'color', 'colorscheme',
+CLUSTER_ATTRIBUTES = { 'K', 'URL', 'bgcolor', 'color', 'colorscheme',
     'fillcolor', 'fontcolor', 'fontname', 'fontsize', 'label', 'labeljust',
     'labelloc', 'lheight', 'lp', 'lwidth', 'nojustify', 'pencolor',
-    'penwidth', 'peripheries', 'sortv', 'style', 'target', 'tooltip'] )
+    'penwidth', 'peripheries', 'sortv', 'style', 'target', 'tooltip' }
 
 
 #
@@ -1817,9 +1817,9 @@ class Dot(Graph):
           then you may want to give the absolute path to the
           executable (for example, to `dot.exe`) in `prog`.
         """
-        default_names = set([
+        default_names = {
             'dot', 'twopi', 'neato',
-            'circo', 'fdp', 'sfdp'])
+            'circo', 'fdp', 'sfdp'}
         if prog is None:
             prog = self.prog
         assert prog is not None

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
     url='https://github.com/erocarrera/pydot',
     license='MIT',
     keywords='graphviz dot graphs visualization',
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
@@ -37,7 +38,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -295,15 +295,15 @@ class TestGraphAPI(unittest.TestCase):
 
         self._reset_graphs()
 
-        names = set([ 'node_%05d' % i for i in range(10**3) ])
+        names = { 'node_%05d' % i for i in range(10**3) }
 
         for name in names:
 
             self.graph_directed.add_node( pydot.Node(name, label=name) )
 
         self.assertEqual(
-            set([n.get_name()
-                 for n in self.graph_directed.get_nodes()]), names)
+            {n.get_name()
+                 for n in self.graph_directed.get_nodes()}, names)
 
 
     def test_executable_not_found_exception(self):

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -375,7 +375,4 @@ if __name__ == '__main__':
     check_path()
     test_dir = os.path.dirname(sys.argv[0])
     print('The tests are using `pydot` from:  {pd}'.format(pd=pydot))
-    if sys.version_info >= (2, 7):
-        unittest.main(verbosity=2)
-    else:
-        unittest.main()
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Python 2.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

Version | Release date | Supported until
--- | ---------- | ----------
2.6 | 2008-10-01 | 2013-10-29

Source: https://en.wikipedia.org/wiki/CPython#Version_history

They're also little used. Here's the pip installs for pydot from PyPI for September 2018:

| category | percent | downloads |
|----------|--------:|----------:|
|      2.7 |  91.71% |   828,789 |
|      3.6 |   3.88% |    35,049 |
|      3.5 |   3.17% |    28,656 |
|      3.7 |   0.52% |     4,706 |
|      2.6 |   0.35% |     3,196 |
|      3.4 |   0.30% |     2,715 |
| null     |   0.06% |       582 |
|      3.3 |   0.01% |        54 |
|      3.8 |   0.00% |         1 |
| Total    |         |   903,748 |


Not only that, Python 2.6 is failing the build due to dependencies having already dropped it. For example, see PR https://github.com/erocarrera/pydot/pull/184 and this master build: https://travis-ci.org/hugovk/pydot/builds/441379823.

This PR drops support for 2.6, upgrades Python syntax with [pyupgrade](https://github.com/asottile/pyupgrade) and adds `python_requires` to help pip install the right version for people still running old Python versions.
