### PR TITLE
Update URLs to Travis CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status][build_img]][travis]
+[![Build Status](https://www.travis-ci.com/pydot/pydot.svg?branch=master)](https://www.travis-ci.com/pydot/pydot)
+[![PyPI](https://img.shields.io/pypi/v/pydot.svg)](https://pypi.org/project/pydot/)
 
 
 About
@@ -55,5 +56,3 @@ Distributed under an [MIT license][10].
 [9]: https://github.com/ellson/graphviz
 [10]: https://github.com/pydot/pydot/blob/master/LICENSE
 [11]: https://github.com/pydot/pydot
-[build_img]: https://travis-ci.org/erocarrera/pydot.svg?branch=master
-[travis]: https://travis-ci.org/erocarrera/pydot


### PR DESCRIPTION
After transferring `pydot` to organisation, URLs to Travis build has been changed.
Additionally it has been migrated grom travis-ci.org to travis-ci.com due
to https://docs.travis-ci.com/user/open-source-on-travis-ci-com