### PR TITLE
Fix comparing of SHA hash in regression tests

### DIFF
--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -228,8 +228,8 @@ class TestGraphAPI(unittest.TestCase):
             os.sys.stdout.write('#')
             os.sys.stdout.flush()
             pydot_sha = self._render_with_pydot(fpath, encoding)
-            pydot_sha = self._render_with_graphviz(fpath, encoding)
-            assert pydot_sha == pydot_sha, (pydot_sha, pydot_sha)
+            graphviz_sha = self._render_with_graphviz(fpath, encoding)
+            assert pydot_sha == graphviz_sha, (pydot_sha, graphviz_sha)
 
     def test_numeric_node_id(self):
 


### PR DESCRIPTION
In 2d55978511fc548dcb989d5553435f8e11c9aead bug in tests were introduced.
When running regression tests, test suite compares outputs
of graph parsed (and rendered) by pydot and rendered directly by
graphviz. To compare, test suite uses SHA hash of the outputs.
The bug was using *the same* SHA hash (of pydot output) when comparing
outputs. This caused regression tests usless.
After fixing this problem, failing regression tests were discovered and
will be gradually fixed.