### PR TITLE
Make attributes order deterministic

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -661,7 +661,7 @@ class Node(Common):
 
         node_attr = list()
 
-        for attr in self.obj_dict['attributes']:
+        for attr in sorted(self.obj_dict['attributes']):
             value = self.obj_dict['attributes'][attr]
             if value == '':
                 value = '""'
@@ -703,7 +703,7 @@ class Edge(Common):
     All the attributes defined in the Graphviz dot language should
     be supported.
 
- 	Attributes can be set through the dynamically generated methods:
+        Attributes can be set through the dynamically generated methods:
 
      set_[attribute name], i.e. set_label, set_fontname
 
@@ -856,7 +856,7 @@ class Edge(Common):
 
         edge_attr = list()
 
-        for attr in self.obj_dict['attributes']:
+        for attr in sorted(self.obj_dict['attributes']):
             value = self.obj_dict['attributes'][attr]
             if value == '':
                 value = '""'
@@ -1494,7 +1494,7 @@ class Graph(Common):
             name=self.obj_dict['name'])
         graph.append(s)
 
-        for attr in self.obj_dict['attributes']:
+        for attr in sorted(self.obj_dict['attributes']):
 
             if self.obj_dict['attributes'].get(attr, None) is not None:
 

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -72,9 +72,8 @@ class TestGraphAPI(unittest.TestCase):
         g.add_node(node)
         node.set('label', 'mine')
         s = g.to_string()
-        s_0 = 'digraph G {\nlegend [label=mine, shape=box];\n}\n'
-        s_1 = 'digraph G {\nlegend [shape=box, label=mine];\n}\n'
-        assert s == s_0 or s == s_1, (s, s_0)
+        expected = 'digraph G {\nlegend [label=mine, shape=box];\n}\n'
+        assert s == expected
 
     def test_attribute_with_implicit_value(self):
 


### PR DESCRIPTION
Attributes of nodes, edges and graphs were random since they were
kept in a dictionary. Now when converting them to strings, they
are sorted so they will always be in the same order.