### PR TITLE
propagate 'SYSTEMROOT' when calling GraphViz

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -122,6 +122,7 @@ def call_graphviz(program, arguments, working_dir, **kwargs):
     env = {
         'PATH': os.environ.get('PATH', ''),
         'LD_LIBRARY_PATH': os.environ.get('LD_LIBRARY_PATH', ''),
+        'SYSTEMROOT': os.environ.get('SYSTEMROOT', ''),
     }
 
     program_with_args = [program, ] + arguments


### PR DESCRIPTION
This commit fixed the error described in issue #203 Problem with graph.write.png...AssertionError: 1.

The dot command in Windows was missing the extra SYSTEMROOT environment variable.
