### PR TITLE
Add index getter/setter into attributes dict for Common base class

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -430,6 +430,14 @@ class Common(object):
         self.obj_dict = state
 
 
+    def __getitem__(self, name):
+        return self.__get_attribute__(name)
+
+
+    def __setitem__(self, name, value):
+        return self.set(name, value)
+
+
     def __get_attribute__(self, attr):
         """Look for default attributes for this node"""
 

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -84,6 +84,25 @@ class TestGraphAPI(unittest.TestCase):
 
         self.assertEqual( 'decorate' in attrs, True )
 
+    def test_attribute_index_access(self):
+
+        d='digraph {\na -> b[label=hello];\n}'
+        graphs = pydot.graph_from_dot_data(d)
+        (g,) = graphs
+        edge, *_ = g.get_edges()
+
+        self.assertEqual( edge['label'], 'hello' )
+
+    def test_attribute_index_setter(self):
+
+        d='digraph {\na -> b[label=hello];\n}'
+        graphs = pydot.graph_from_dot_data(d)
+        (g,) = graphs
+        edge, *_ = g.get_edges()
+        self.assertEqual( edge['label'], 'hello' )
+        edge['label'] = 'world'
+        self.assertEqual( edge['label'], 'world' )
+
 
     def test_subgraphs(self):
 


### PR DESCRIPTION
This allows for getting and setting Edge attributes with attribute names stored in variables, i.e.
```python
# Makes refactoring easier if graph representation 
# changes attribute name for label,
# just need to change variable content rather than
# changing `get_label` to `get_newLabelName` everywhere

attrs = ('label', 'payload')

# Reuse everywhere
label, payload = (edge[attr] for attr in attrs])
```