### PR TITLE
Prevent TypeError in handling of DOT parser error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,7 +4,7 @@
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix: Prevent TypeError in handling of DOT parser error (#176)
 
 
 1.4.1 (2018-12-12)

--- a/dot_parser.py
+++ b/dot_parser.py
@@ -548,8 +548,7 @@ def parse_dot_data(s):
         tokens = graphparser.parseString(s)
         return list(tokens)
     except ParseException as err:
-        print(
-            err.line +
-            " "*(err.column-1) + "^" +
-            err)
+        print(err.line)
+        print(" " * (err.column - 1) + "^")
+        print(err)
         return None


### PR DESCRIPTION
_From the commit message:_

When parsing DOT strings or files, pydot's parser calls the third-party library PyParsing. If PyParsing meets a problem, it raises a `ParseException`, which pydot then uses to report some details.

Currently, during the handling of that exception, a `TypeError` occurs. It is caused by an attempt to concatenate a string with the exception using the `+` (addition/plus) operator, which is [not allowed][1]. The problem was introduced in 2016 by commit [b4a38103][2].

This current commit now removes that concatenation and goes back to printing three separate lines. The end result is the same as @nlhepler's [original 2013 solution][3] and [the example code in the PyParsing documentation][4].

I tested that behavior is now as expected (printing parser error details without `TypeError`) under Python 2.7.16 with PyParsing 2.4.2 and Python 3.7.3 with PyParsing 2.4.2 and 3.0.0a2 ([486b1fd2e][5]). Unit tests all pass (same three combinations, when run together with the test suite fix proposed in PR 211).

This [closes #176][6] ("Error in error handling hides the real error message"), reported by Shish, and resolves the `TypeError` part of [issue #171][7] ("Exception on parsing dot file"), reported by Michael Goerz.

[1]: https://docs.python.org/3/reference/expressions.html#binary-arithmetic-operations
[2]: https://github.com/pydot/pydot/commit/b4a38103a553cbc7f0fa3fdd530e8e1fcfdba7f9#diff-baef597193866f900a2726a8a4667b12R563-R566
[3]: https://github.com/nlhepler/pydot/commit/687eb7e18c3d0cc890557e8874b13f7f1b802667#diff-baef597193866f900a2726a8a4667b12R551-R553
[4]: https://github.com/pyparsing/pyparsing/commit/2c6f881943ecf0fbf02354623b51cc0566325c75#diff-7ab8c6f0d66d170e10b60b9f65334e18R694-R697
[5]: https://github.com/pyparsing/pyparsing/tree/486b1fd2ef7e98966665f915bc59856996ffb5b0
[6]: https://github.com/pydot/pydot/issues/176
[7]: https://github.com/pydot/pydot/issues/171

_Additional remarks:_

- The main purpose of commit [b4a38103][2] of 2016-06-29 (v1.2.0) was to switch printing from using the (Python 2) `print` statement to using the `print()` function. However, for the printing of parser exception details, it additionally attempted to reduce the three `print` statements to one `print()` call with the use of `+`, leading to the bug. (The additional change may very well not have originated from the person mentioned as the commit's Author, by the way.)

- Back to the change proposed here. The exact error messages before the proposed change:
  
  Python 2.7:
  
      TypeError: cannot concatenate 'str' and 'ParseException' objects
  
  Python 3.7:
  
      TypeError: can only concatenate str (not "ParseException") to str

- And the example output after the proposed change (Python 3.7.3 and PyParsing 2.4.2):
  
      >>> pydot.graph_from_dot_data("graph { n [label=<some complex problematic DOT string>>]; }")
      graph { n [label=<some complex problematic DOT string>>]; }
                ^
      Expected "}", found '['  (at char 10), (line:1, col:11)
  
  (This is also an error, but the kind of error originally intended, so this is correct behavior.)

- Alternative solutions:
  - Wrap `err` as `str(err)`. However, the newlines are still missing then.
  - String formatting was not used in order to keep this bug fix as minimal as possible.

- This PR #227 was spun off from PR #219. A more extensive change to the parser error handling is currently being discussed in issue #171 and PR #219. However, that extensive change may get released as part of a major/minor release to which upgrading might not be an option for all users (e.g. because of a coincidental drop of Python 2 support). Therefore, this PR #227 provides a minimal bug fix to be used for bug fix/point releases or backporting.