### PR TITLE
Store Subgraph and Cluster edge points by name

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -695,11 +695,11 @@ class Edge(Common):
 
     edge(src, dst, attribute=value, ...)
 
-    src: source node
-    dst: destination node
+    src: source node, subgraph or cluster
+    dst: destination node, subgraph or cluster
 
-    `src` and `dst` can be specified as a `Node` object,
-    or as the node's name string.
+    `src` and `dst` can be specified as a `Node`, `Subgraph` or
+    `Cluster` object, or as the name string of such a component.
 
     All the attributes defined in the Graphviz dot language should
     be supported.
@@ -719,9 +719,9 @@ class Edge(Common):
 
     def __init__(self, src='', dst='', obj_dict=None, **attrs):
         self.obj_dict = dict()
-        if isinstance(src, Node):
+        if isinstance(src, (Node, Subgraph, Cluster)):
             src = src.get_name()
-        if isinstance(dst, Node):
+        if isinstance(dst, (Node, Subgraph, Cluster)):
             dst = dst.get_name()
         points = (quote_if_necessary(src),
                   quote_if_necessary(dst))

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -347,6 +347,35 @@ class TestGraphAPI(unittest.TestCase):
         g.write_svg('test.svg', prog=['twopi', '-Goverlap=scale'])
 
 
+    def test_edge_point_namestr(self):
+        self._reset_graphs()
+        self.graph_directed.add_edge(pydot.Edge('a', 'b'))
+        self.assertEqual(
+            self.graph_directed.get_edges()[0].to_string(), 'a -> b;')
+
+    def test_edge_point_object_node(self):
+        self._reset_graphs()
+        self.graph_directed.add_edge(pydot.Edge(pydot.Node('a'),
+            pydot.Node('b')))
+        self.assertEqual(
+            self.graph_directed.get_edges()[0].to_string(), 'a -> b;')
+
+    def test_edge_point_object_subgraph(self):
+        self._reset_graphs()
+        self.graph_directed.add_edge(pydot.Edge(pydot.Subgraph('a'),
+            pydot.Subgraph('b')))
+        self.assertEqual(
+            self.graph_directed.get_edges()[0].to_string(), 'a -> b;')
+
+    def test_edge_point_object_cluster(self):
+        self._reset_graphs()
+        self.graph_directed.add_edge(pydot.Edge(pydot.Cluster('a'),
+            pydot.Cluster('b')))
+        self.assertEqual(
+            self.graph_directed.get_edges()[0].to_string(),
+                'cluster_a -> cluster_b;')
+
+
 def check_path():
     not_check = parse_args()
     if not_check:


### PR DESCRIPTION
_Commit message:_
When instantiating a new `Edge`, if the caller supplies a `Subgraph` or `Cluster` object as an edge point, store only the name string of that object, same as we do for `Node` objects as edge points.

According to the DOT Language definition ([1]) an edge point may be a node or a subgraph. Clusters are just subgraphs whose names begin with `cluster`, so those are also allowed.

Although not documented, the `Edge` constructor already accepts subgraphs and clusters as edge points as long as they are in the form of name strings. These strings are stored in `Edge.obj_dict['points']` and get included in the writing of a DOT string (`Edge.to_string()`), just as name strings of nodes would.

However, until now, this is different when an edge point is supplied as an object. For a `Node`, the name string gets looked up and stored in `Edge.obj_dict['points']`, but `Subgraph` and `Cluster` objects are stored there directly as objects.

This leads to problems when `Edge.to_string()` tries to concatenate the different parts of the edge, with errors like:

    TypeError: unsupported operand type(s) for +: 'Subgraph' and 'str'

    TypeError: sequence item 2: expected str instance, Cluster found

I did not find any explanation for the difference, nor any code that depends on the points being stored as objects.

The alternative of storing objects across the line was not chosen, because it would have much larger implications both for the pydot code itself as for existing user code. Worth considering for the long term maybe, but this commit provides a bug fix in the current context.

Fixes pydot/pydot#89.

[1]: https://www.graphviz.org/doc/info/lang.html

_Further remarks:_
@prmtl @ankostis or others: Reviews/comments still very much welcome of course!