### PR TITLE
AssertionError -> RuntimeError

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1943,6 +1943,12 @@ class Dot(Graph):
             )
             print(message)
 
-        assert process.returncode == 0, process.returncode
+        assert process.returncode == 0, (
+                '"{prog}" with args {arguments} returned code: {code}'.format(
+                    prog=prog,
+                    arguments=arguments,
+                    code=process.returncode,
+                )
+            )
 
         return stdout_data


### PR DESCRIPTION
Currently getting a macOS failure within a larger software stack, and do not see the message printed to stdout.

Replace a traceback with "AssertionError: 1" with the meaningful message, since this is not useful:

```
Traceback (most recent call last):
...
  File "/Users/xxx/miniconda3/lib/python3.7/site-packages/networkx/drawing/nx_pydot.py", line 257, in graphviz_layout
    return pydot_layout(G=G, prog=prog, root=root)
  File "/Users/xxx/miniconda3/lib/python3.7/site-packages/networkx/drawing/nx_pydot.py", line 306, in pydot_layout
    D_bytes = P.create_dot(prog=prog)
  File "/Users/xxx/miniconda3/lib/python3.7/site-packages/pydot.py", line 1723, in new_method
    format=f, prog=prog, encoding=encoding)
  File "/Users/xx/miniconda3/lib/python3.7/site-packages/pydot.py", line 1945, in create
    assert process.returncode == 0, process.returncode
AssertionError: 1
```
