### PR TITLE
bug fixes, API changes, documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
-Copyright (c) 2014 Carlos Jenkins
-Copyright (c) 2014 Lance Helper
-Copyright (c) 2004 Ero Carrera
+Copyright (c) 2004 by Ero Carrera
+Copyright (c) 2014 by Lance Helper
+Copyright (c) 2014 by Carlos Jenkins
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2004 by Ero Carrera
+Copyright (c) 2004-2020 by Ero Carrera
 Copyright (c) 2014 by Lance Helper
 Copyright (c) 2014 by Carlos Jenkins
 

--- a/dot_parser.py
+++ b/dot_parser.py
@@ -471,7 +471,7 @@ def graph_definition():
 
         node_id = (ID + Optional(port))
         a_list = OneOrMore(ID + Optional(equals + righthand_id) +
-            Optional(comma.suppress())).setName("a_list")
+            Optional((semi | comma).suppress())).setName("a_list")
 
         attr_list = OneOrMore(lbrack.suppress() + Optional(a_list) +
             rbrack.suppress()).setName("attr_list")

--- a/pydot.py
+++ b/pydot.py
@@ -13,7 +13,7 @@ import warnings
 
 try:
     import dot_parser
-except Exception as e:
+except ImportError as e:
     warnings.warn(
         "Couldn't import dot_parser, "
         "loading of dot files will not be possible.")

--- a/pydot.py
+++ b/pydot.py
@@ -1309,25 +1309,15 @@ class Graph(Common):
 
         return False
 
-
-    def get_edge(self, src_or_list, dst=None):
-        """Retrieved an edge from the graph.
-
-        Given an edge's source and destination the corresponding
-        Edge instance(s) will be returned.
+    def get_edge(self, src, dst):
+        """Return edges with from node `src` to node `dst`.
 
         If one or more edges exist with that source and destination
-        a list of Edge instances is returned.
-        An empty list is returned otherwise.
+        return a `list` of `Edge` instances.
+        Otherwise, return an empty `list`.
         """
-
-        if isinstance( src_or_list, (list, tuple)) and dst is None:
-            edge_points = tuple(src_or_list)
-            edge_points_reverse = (edge_points[1], edge_points[0])
-        else:
-            edge_points = (src_or_list, dst)
-            edge_points_reverse = (dst, src_or_list)
-
+        edge_points = (src, dst)
+        edge_points_reverse = tuple(reversed(edge_points))
         match = list()
 
         if edge_points in self.obj_dict['edges'] or (

--- a/pydot.py
+++ b/pydot.py
@@ -991,7 +991,11 @@ class Graph(Common):
 
 
     def set_node_defaults(self, **attrs):
+        """Define default node attributes.
 
+        These attributes apply to only nodes created after
+        calling this method.
+        """
         self.add_node( Node('node', **attrs) )
 
 

--- a/pydot.py
+++ b/pydot.py
@@ -15,8 +15,9 @@ try:
     import dot_parser
 except ImportError as e:
     warnings.warn(
-        "Couldn't import dot_parser, "
-        "loading of dot files will not be possible.")
+        "`pydot` could not import `dot_parser`, "
+        "so `pydot` will be unable to parse DOT files. "
+        "The error was:  {e}".format(e=e))
 
 
 __author__ = 'Ero Carrera'

--- a/pydot.py
+++ b/pydot.py
@@ -1318,24 +1318,25 @@ class Graph(Common):
         """
         edge_points = (src, dst)
         edge_points_reverse = tuple(reversed(edge_points))
-        match = list()
-
-        if edge_points in self.obj_dict['edges'] or (
-            self.get_top_graph_type() == 'graph' and
-            edge_points_reverse in self.obj_dict['edges']):
-
-            edges_obj_dict = self.obj_dict['edges'].get(
-                edge_points,
-                self.obj_dict['edges'].get( edge_points_reverse, None ))
-
-            for edge_obj_dict in edges_obj_dict:
-                match.append(
-                    Edge(edge_points[0],
-                         edge_points[1],
-                         obj_dict=edge_obj_dict))
-
-        return match
-
+        matches = list()
+        # collect edges
+        edges = self.obj_dict['edges']
+        is_directed = self.get_top_graph_type() != 'graph'
+        has_edge = edge_points in edges
+        has_reverse_edge = edge_points_reverse in edges
+        if has_edge:
+            edges_obj_dict = edges.get(edge_points, list())
+        if has_reverse_edge and not is_directed:
+            more = edges.get(edge_points_reverse, list())
+            edges_obj_dict.extend(more)
+        # output
+        if not edges_obj_dict:
+            return matches
+        for edge_obj_dict in edges_obj_dict:
+            a, b = edge_obj_dict['points']
+            e = Edge(a, b, obj_dict=edge_obj_dict)
+            matches.append(e)
+        return matches
 
     def get_edges(self):
         return self.get_edge_list()


### PR DESCRIPTION
- API:
  - require two positional arguments `src` and `dst` in `get_edge`
  - catch `ImportError`, instead of `Exception`
- BUG:
  - return both aligned and reversed edges from `get_edge`
  - allow semicolon as attribute separator
- DOC:
  - improve warning message about `dot_parser`
  - clarify the effect of calling the method `set_node_defaults`
- REL:
  - update file `LICENSE`