### PR TITLE
Add ppc64le and bump Python versions in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 if: tag IS present OR type = pull_request OR (branch = master AND type = push)   # we only CI the master, tags and PRs
 language: python
 
+# Main test jobs: The lowest and highest current Python versions.
 python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
-  - "3.6"
-  - "3.7"
+  - 3.6
+  - 3.9
+
+# List additional test configurations individually, instead of using
+# matrix expansion, to prevent an exponential growth of test jobs.
+matrix:
+  include:
+    # Python versions that are EOL, but we still support.
+    # PY2.7 here should bring out any PY3.5 incompatibilities as well.
+    - python: 2.7
+      arch: amd64
+    # pydot itself should be architecture-independent. Still, some
+    # limited testing on other architectures to catch corner cases.
+    - python: 2.7
+      arch: ppc64le
+    - python: 3.9
+      arch: ppc64le
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
+  - "3.7"
 
 addons:
   apt:


### PR DESCRIPTION
<details><summary>Outdated description of outdated commit 2d60c6ed. Updated description in <a href="https://github.com/pydot/pydot/pull/245#issuecomment-727197060">my comment of 2020-11-14 below</a>.</summary>
Considering that:

- IBM, through its supplier Datamatics, requested many Python projects to [add the `ppc64le` (Power) architecture][1] to their Travis CI test matrices. This request was also made to pydot in PR [pydot/pydot#243][2] by GitHub user @asellappen.
- Some related links:
  - ibm.com: [Build your open source projects on IBM Power Systems with Travis CI][3].
  - youtube.com: [OpenPOWER Summit NA 2019: Developing Applications using Acceleration Hardware on Power][4].
- Gerrit Huizenga of IBM (@gerrith3 on GitHub) said he thinks this will not lead to additional billing from Travis CI to the OSS community, because [he provides Travis CI with the Power hardware][5].
- The [Travis CI documentation on CPU architectures][6] currently says IBM architecture support is in beta stage and only available for Open Source repositories.
- There are many abstraction layers between pydot and the hardware architecture, including other libraries, Python and the operating system. Pydot itself does not need to be compiled for a specific architecture. In a perfect world, pydot is architecture-independent and testing pydot on a single architecture should be sufficient.
- However, the world is not perfect and [abstraction layers can be leaky][7]. According to Gerrit Huizenga of IBM, [corner cases do come up][8], which is why they do so much testing up front and provide free access to testing.
- Still, even if an automated testing service is provided for free, it has an [environmental footprint][9], so there are limits to how much we should make use of that as well.
- Travis CI also requests open-source users to remember that Travis CI provides its service free of charge to the community and only specify the matrix we [actually need][10].

After weighing all of the above, I prefer not to extend the number of builds by [matrix expansion][11] as proposed by IBM, because that would multiply the number of builds by a factor of 2: 5 Python versions * 2 architectures = 10 builds of 2 to 3 minutes each.

Instead, I propose we list individual build jobs based on the following two ideas:

- We only build for all architectures for the lowest and the highest Python versions.
- We only test the Python versions in-between on one architecture each, though that does not necessarily have to be amd64. Preferably, we just step diagonally between the different architectures and the in-between Python versions.

This way, we only increase the number of automated Travis CI builds from 5 to 7, so by 40% instead of the 100% increase of the original request.

We can always reconsider this policy if some real examples come up of pydot bugs specific to a combination of an in-between Python version and a specific architecture.

[1]: https://github.com/pulls?q=author%3Aasellappen+ppc64le+travis
[2]: https://github.com/pydot/pydot/pull/243
[3]: https://developer.ibm.com/tutorials/travis-ci-on-power/
[4]: https://www.youtube.com/watch?v=qPZtf3hoMSs
[5]: https://github.com/nrdcg/goinwx/pull/5#issuecomment-721422838
[6]: https://docs.travis-ci.com/user/multi-cpu-architectures/
[7]: https://www.joelonsoftware.com/2002/11/11/the-law-of-leaky-abstractions/
[8]: https://github.com/nrdcg/goinwx/pull/5#issuecomment-719084047
[9]: https://en.wikipedia.org/wiki/Data_center#Energy_use
[10]: https://docs.travis-ci.com/user/build-matrix/#listing-individual-jobs
[11]: https://docs.travis-ci.com/user/build-matrix/#matrix-expansion
</details>

@asellappen and @gerrith3: Let me know what you think of this instead of pydot/pydot#243.
@ldez: Thanks for asking in https://github.com/nrdcg/goinwx/pull/5 many of the questions I also had.

The other commit in this PR removes the workaround for the Python 3.7 test environment added by commit eb7aef13. It is no longer needed by travis-ci.com.