### PR TITLE
Make Edge not-equal comparison on PY2 same as PY3

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@
 1.4.2 (unreleased)
 ------------------
 
+- Edge not-equal-comparison on Python 2 now same as on Python 3 (#248)
 - Fix: Prevent TypeError in handling of DOT parser error (#176)
 
 

--- a/pydot.py
+++ b/pydot.py
@@ -794,7 +794,12 @@ class Edge(Common):
 
         return False
 
-
+    if not PY3:
+        def __ne__(self, other):
+            result = self.__eq__(other)
+            if result is NotImplemented:
+                return NotImplemented
+            return not result
 
     def parse_node_ref(self, node_str):
 

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -346,6 +346,14 @@ class TestGraphAPI(unittest.TestCase):
         g.add_node(u)
         g.write_svg('test.svg', prog=['twopi', '-Goverlap=scale'])
 
+    def test_edge_equality_basics_3_same_points_not_not_equal(self):
+        # Fail example: pydot 1.4.1 on Python 2.
+        g = pydot.Graph()
+        e1 = pydot.Edge('a', 'b')
+        e2 = pydot.Edge('a', 'b')
+        g.add_edge(e1)
+        g.add_edge(e2)
+        self.assertFalse(e1 != e2)
 
     def test_edge_point_namestr(self):
         self._reset_graphs()


### PR DESCRIPTION
Currently, a non-equality comparison (`!=`) of two separate, but equal `Edge` instances returns `False` as expected on Python 3, but `True` on Python 2. There is no such difference in equality comparison (`==`, `True` in this case) between Python 2 and 3.

The difference for non-equality is caused by the lack of an `Edge.__ne__()` method. In Python 3, [`__ne__()` by default delegates to `__eq__()`][1], but in Python 2 there are [no implied relationships among the comparison operators][2], resulting in a fallback to [identity-based comparison][3].

This commit fixes that by defining an `Edge.__ne__()` method only for Python 2.

There is some [discussion about how to best implement an `__ne__()` method][4], centering on the following two alternatives:

    def __ne__(self, other):
        return not self == other

or variations of:

    def __ne__(self, other):
        equal = self.__eq__(other)
        return equal if equal is NotImplemented else not equal

The discussion goes from optimal delegation order to symmetry to performance and so forth. In short, I got the impression they are never going to convince each other, because the first solution focuses more on the `self` and `!=` and `==` being complements, whereas the second solution focuses more on the symmetry of `!=` when swapping `self` and `other`. It seems there are cases where you simply cannot have both. In the end, I just tested both solutions against a variety of made-up classes and chose the second solution, because it exactly mimicked the Python 3 behavior in all cases, whereas the first clearly gave different results sometimes, e.g. against a class with comparison methods that always return `False`. Although such cases may be called pathological, the main goal of this commit is to get the behavior on Python 2 in line with the default behavior of Python 3 that we are used to, not to come up with a better (or worse) custom `Edge.__ne__()` for Python 3 as well.

Note that on comparison with non-`Edge` objects, `Edge.__eq__()` currently raises an `Error` instead of returning `NotImplemented`, so this will also happen for `Edge`-to-non-`Edge` non-equality comparisons on Python 2 now. This is consistent with existing behavior on Python 3. Changing this to `NotImplemented` will be proposed later.

API impact: I expect the number of affected users to be minimal, because the old behavior on Python 2 was quite surprising, yet we never had any bug reports about it. I assume `Edge` objects are seldom checked for non-equality, or for non-identity by checking non-equality. Also, any breakage may already have been discovered when running code on Python 3 sometimes. I have not seen any explicit promises made for the old behavior on Python 2.

[1]: https://docs.python.org/3.9/reference/datamodel.html#object.__eq__
[2]: https://docs.python.org/2.7/reference/datamodel.html#object.__eq__
[3]: https://docs.python.org/2.7/reference/expressions.html#value-comparisons
[4]: https://stackoverflow.com/questions/4352244/should-i-implement-ne-in-terms-of-eq-in-python/