### PR TITLE
Fix string formatting and basic tests adjacency/incidence matrix

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@
 
 - Edge not-equal-comparison on Python 2 now same as on Python 3 (#248)
 - Fix: Prevent TypeError in handling of DOT parser error (#176)
+- Fix: Prevent TypeError in `graph_from_adjacency_matrix()` and
+  `graph_from_incidence_matrix()` (#98)
 
 
 1.4.1 (2018-12-12)

--- a/pydot.py
+++ b/pydot.py
@@ -366,13 +366,12 @@ def graph_from_adjacency_matrix(matrix, node_prefix= u'', directed=False):
         for e in r:
             if e:
                 graph.add_edge(
-                    Edge( node_prefix + node_orig,
-                        node_prefix + node_dest) )
+                    Edge('%s%s' % (node_prefix, node_orig),
+                         '%s%s' % (node_prefix, node_dest)))
             node_dest += 1
         node_orig += 1
 
     return graph
-
 
 
 def graph_from_incidence_matrix(matrix, node_prefix='', directed=False):
@@ -403,8 +402,8 @@ def graph_from_incidence_matrix(matrix, node_prefix='', directed=False):
 
         if len(nodes) == 2:
             graph.add_edge(
-                Edge( node_prefix + abs(nodes[0]),
-                    node_prefix + nodes[1] ))
+                Edge('%s%s' % (node_prefix, abs(nodes[0])),
+                     '%s%s' % (node_prefix, nodes[1])))
 
     if not directed:
         graph.set_simplify(True)

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -413,6 +413,26 @@ class TestGraphAPI(unittest.TestCase):
             self.graph_directed.get_edges()[0].to_string(),
                 'cluster_a -> cluster_b;')
 
+    def test_graph_from_adjacency_matrix(self):
+        g = pydot.graph_from_adjacency_matrix(
+            [[0, 1, 0], [1, 0, 0], [0, 1, 1]], directed=True)
+        s = ' '.join(g.to_string().split())
+        self.assertEqual(s, 'digraph G { 1 -> 2; 2 -> 1; 3 -> 2; 3 -> 3; }')
+        g = pydot.graph_from_adjacency_matrix(
+            [[0, 1, 0], [1, 0, 0], [0, 0, 1]], directed=False)
+        s = ' '.join(g.to_string().split())
+        self.assertEqual(s, 'graph G { 1 -- 2; 3 -- 3; }')
+
+    def test_graph_from_incidence_matrix(self):
+        g = pydot.graph_from_incidence_matrix(
+            [[-1, 1, 0], [1, -1, 0], [0, 1, -1]], directed=True)
+        s = ' '.join(g.to_string().split())
+        self.assertEqual(s, 'digraph G { 1 -> 2; 2 -> 1; 3 -> 2; }')
+        g = pydot.graph_from_incidence_matrix(
+            [[1, 1, 0], [0, 1, 1]], directed=False)
+        s = ' '.join(g.to_string().split())
+        self.assertEqual(s, 'graph G { 1 -- 2; 2 -- 3; }')
+
 
 def check_path():
     not_check = parse_args()


### PR DESCRIPTION
The first commit prevents these error messages from `graph_from_adjacency_matrix()` and `graph_from_incidence_matrix()`:

    TypeError: can only concatenate str (not "int") to str
    TypeError: cannot concatenate 'str' and 'int' objects
    TypeError: coercing to Unicode: need string or buffer, int found

Fixes pydot/pydot#98.

The second commit adds some basic tests for these functions.