### PR TITLE
Compass point and quotes around colons

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -794,7 +794,7 @@ class Edge(Common):
         else:
             new_compass_pt = {}
             # Make sure the compass point is valid, if not, do not set it.
-            unexpected_keys = compass_pt.keys() - {'src', 'dst'}
+            unexpected_keys = set(compass_pt.keys()) - {'src', 'dst'}
             if unexpected_keys:
                 raise Error('Compass must contain key(s) "src" and/or "dst"')
             if 'src' in compass_pt:

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -433,6 +433,19 @@ class TestGraphAPI(unittest.TestCase):
         s = ' '.join(g.to_string().split())
         self.assertEqual(s, 'graph G { 1 -- 2; 2 -- 3; }')
 
+    def test_graph_compass_pt(self):
+        node1 = pydot.Node('a')
+        node2 = pydot.Node('b:b:c', fillcolor='red:yellow')
+        g = pydot.Dot()
+        g.add_node(node1)
+        g.add_node(node2)
+        g.add_edge(pydot.Edge(node1, node2, compass_pt={'src': 'e', 'dst': 'e'} ))
+        g.add_edge(pydot.Edge(node1, 'b:b:c', compass_pt={'src': 'w', 'dst': 'w'} ))
+        s = ' '.join(g.to_string().split())
+        self.assertEqual(
+            s, 'digraph G { a; "b:b:c" [fillcolor="red:yellow"]; a:e -> "b:b:c":e; a:w -> "b:b:c":w; }' )
+        breakpoint()
+
 
 def check_path():
     not_check = parse_args()

--- a/test/pydot_unittest.py
+++ b/test/pydot_unittest.py
@@ -444,7 +444,6 @@ class TestGraphAPI(unittest.TestCase):
         s = ' '.join(g.to_string().split())
         self.assertEqual(
             s, 'digraph G { a; "b:b:c" [fillcolor="red:yellow"]; a:e -> "b:b:c":e; a:w -> "b:b:c":w; }' )
-        breakpoint()
 
 
 def check_path():


### PR DESCRIPTION
Related to https://github.com/pydot/pydot/issues/224, https://github.com/pydot/pydot/issues/258

I've taken the `COMPASS_POINTS` from [here](https://graphviz.org/doc/info/lang.html). IMO this could be a slightly bigger rework for the `quote_if_necessary` and `quotes_needed` as it seems like it would benefit from that. Would be very nice to add typing to this as well.

Additional, I think this implementation is quite ugly. It could be done using Tuples or a Dataclass etc

I'd like to add more tests although would be good to get another opinion on this approach. I may make some edits in the near future.

I had a check as to why the tests are failing. It seems that the '.dot' files that contain either a port or a compass point are being processed unexpectedly. This seems to be due to the fact that `test_graphviz_regression_tests` _eventually_ calls the `pydot.Edge(...)` function which calls `quote_if_necessary`. So my change needs to be smarter or there needs to be a further changes to how either a string (of a DOT file) / or a DOT file itself is parsed. I believe this is handled in the `dot_parser.py` file for the function `push_edge_stmt`.