### PR TITLE
Added .exe extension to Dot self.prog when running on standard / pure…

### DIFF
--- a/pydot.py
+++ b/pydot.py
@@ -1722,6 +1722,11 @@ class Dot(Graph):
 
         self.prog = 'dot'
 
+        # For standard windows (i.e. not cygwin etc) add ".exe"
+        # to self.prog as windows execuatbles have the .exe extension.
+        if sys.platform.startswith('win32'):
+          self.prog += ".exe"
+
         # Automatically creates all
         # the methods enabling the creation
         # of output in any of the supported formats.


### PR DESCRIPTION
… windows (i.e. not cygwin).

.exe is appended to self.prog for windows as opposed to assigning by if or in turnary operator to reduce code change required in case self.prog base name changes (i.e. dot to awesome_dot etc)