### PR TITLE
add a timeout to avoid hanging forever in some cases

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -128,7 +128,7 @@ def call_graphviz(program, arguments, working_dir, **kwargs):
         "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),
     }
 
-    program_with_args = [program] + arguments
+    program_with_args = ['timeout', '15'] + [program] + arguments
 
     process = subprocess.Popen(
         program_with_args,


### PR DESCRIPTION
In some cases, `dot` will hang and this pydot's `call_graphviz` will never return. To fix it, add a time out to avoid the forever hanging.