### PR TITLE
fix output problems when setting non-default progs

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1591,7 +1591,7 @@ class Dot(Graph):
         # of output in any of the supported formats.
         for frmt in self.formats:
 
-            def new_method(f=frmt, prog=self.prog, encoding=None):
+            def new_method(f=frmt, prog=None, encoding=None):
                 """Refer to docstring of method `create`."""
                 return self.create(format=f, prog=prog, encoding=encoding)
 
@@ -1600,7 +1600,7 @@ class Dot(Graph):
 
         for frmt in self.formats + ["raw"]:
 
-            def new_method(path, f=frmt, prog=self.prog, encoding=None):
+            def new_method(path, f=frmt, prog=None, encoding=None):
                 """Refer to docstring of method `write.`"""
                 self.write(path, format=f, prog=prog, encoding=encoding)
 


### PR DESCRIPTION
I found an output problem when setting non-default `prog`s and calling `create_*` or `write_*` functions.
This PR fixes the problem.


The following code reproduces the problem.

Python version: 3.9.6
pydot version: 2.0.0.dev0 (latest)
dot (graphviz) version: 2.43.0

```python
import pydot

dot_string = """graph my_graph {
    bgcolor="yellow";
    a [label="Foo"];
    b [shape=circle];
    a -- b -- c [color=blue];
}"""

graphs = pydot.graph_from_dot_data(dot_string)
graph = graphs[0]
graph.set_prog('neato')
with open('sample1.png', 'wb') as f:
    f.write(graph.create_png())
with open('sample2.png', 'wb') as f:
    f.write(graph.create(format='png'))
graph.write_png('sample3.png')
graph.write('sample4.png', format='png')
```

The outputs are following.

sample1
![sample1](https://user-images.githubusercontent.com/5166128/132002079-a69a6838-b4d0-43b2-88a2-29a27b9b303e.png)
sample2
![sample2](https://user-images.githubusercontent.com/5166128/132002075-766c6a55-c814-4f63-9e0d-ed2caba62115.png)
sample3
![sample3](https://user-images.githubusercontent.com/5166128/132002077-e12d8258-317e-4971-b477-2a25fe209a9f.png)
sample4
![sample4](https://user-images.githubusercontent.com/5166128/132002078-a6134559-6b3c-4b96-8d32-4620faef0d9b.png)

I expect that all outputs are the same, but they are not.
`sample1.png` and `sample3.png` (from `create_png` and `write_png`) seem wrong since they do not reflect the attributes `prog='neato'`.

I checked only the single case `prog=neato` and `format=png`, but I guess that the same problems will occur for all other parameters.

If this behavior is intentional, please ignore the PR.