### PR TITLE
Update gitignore to contain test.svg and .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+test.svg
 
 # Translations
 *.mo
@@ -109,3 +110,6 @@ venv.bak/
 .mypy_cache/
 .dmypy.json
 dmypy.json
+
+# OS-generated files
+.DS_Store


### PR DESCRIPTION
A file `test.svg` is generated by tests. It should not be looked at by git. Additionally, for Mac users, `.DS_Store` is an OS-generated file that can appear anywhere. It should be hidden too.