### PR TITLE
Add workflow job to label PRs with conflicts

### DIFF
--- a/.github/workflows/label-conflicts.yml
+++ b/.github/workflows/label-conflicts.yml
@@ -1,0 +1,28 @@
+name: "Label merge conflicts"
+on:
+  # So that PRs touching the same files as the push are updated
+  push:
+  # So that the `dirtyLabel` is removed if conflicts are resolve
+  # We recommend `pull_request_target` so that github secrets are available.
+  # In `pull_request` we wouldn't be able to change labels of fork PRs
+  pull_request_target:
+    # GitHub documents "synchronize" as:
+    # A pull request's head branch was updated. For example, the head branch
+    # was updated from the base branch or new commits were pushed to the
+    # head branch.
+    types: [synchronize]
+
+jobs:
+  conflicts:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: check if PRs are mergeable
+        uses: eps1lon/actions-label-merge-conflict@v2.1.0
+        with:
+          dirtyLabel: "conflicts"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has conflicts, please resolve those so that the changes can be evaluated."
+          commentOnClean: "All conflicts have been resolved, thanks!"
+


### PR DESCRIPTION
A purely take-it-or-leave-it PR, to add a tool that I find helpful in upstream repos. The workflow added by this PR will scan each open PR in the repo, after every change to the source or target branches, and check whether merge conflicts have appeared (or disappeared). 

If conflicts are found, it will then both:

1. Add a comment to the PR, requesting that the conflicts be addressed.
2. Label the PR with the selected label (Currently set to "conflicts"), so that the presence of conflicts is visible in the PR overview listing.

If prior conflicts have been resolved, it will:

1. Comment on the PR, thanking the submitter for addressing the issue.
2. Remove the "conflicts" label.

It's a handy replacement for a feature GitHub _should_ provide themselves, but inexplicably still do not.

## IMPORTANT PREREQUISITE

This workflow _will not work_, unless the label it is configured to use is **created manually** before merging it.

As I said, the currently-configured label name is `conflicts` (all-lowercase), which is how the label should be created at https://github.com/pydot/pydot/labels (unless we decide to change it). Color is irrelevant, though I suggest `#ff0000` red so that it stands out clearly in the PR list.