### PR TITLE
Update MANIFEST.in for better sdist contents

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,10 @@
 include README.md
 include LICENSE
 include ChangeLog
-include requirements.txt
-include test/*_unittest.py
-include test/graphs/*.dot
-include test/my_tests/*.dot
+include *.txt
+prune .github
+exclude .git*
+graft test
+prune test/from-past-to-future
+global-exclude test.svg
+


### PR DESCRIPTION
A quick pre-2.0.0 tweak (if I made it in time).

When running `prerelease` from `zest.releasing`, its check-manifest scan registers some mismatches between the repo and the sdist. These changes to the `MANIFEST.in` ensure that the check passes, and the sdist contents are exactly what we/zest expect.