### PR TITLE
Add Windows and macOS CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,11 +21,16 @@ concurrency:
 
 jobs:
   tests:
-    name: "Test with Python ${{ matrix.python-version }}"
-    runs-on: "ubuntu-latest"
+    name: "${{ matrix.system.os }}, Py${{ matrix.python-version }}"
+    runs-on: "${{ matrix.system.os }}-latest"
+    continue-on-error: ${{ matrix.system.can-fail }}
 
     strategy:
       matrix:
+        system:
+          - {os: ubuntu, can-fail: false}
+          - {os: windows, can-fail: true}
+          - {os: macos, can-fail: false}
         python-version:
           - "3.12"
           - "3.11"
@@ -42,12 +47,21 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pip"
-      - name: "Install dependencies"
+      - name: "Install graphviz (Linux)"
+        if: runner.os == 'linux'
+        run: sudo apt install graphviz
+      - name: "Install graphviz (Windows)"
+        if: runner.os == 'windows'
+        run: choco install graphviz
+      - name: "Install graphviz (macOS)"
+        if: runner.os == 'macos'
+        run: brew install graphviz
+      - name: "Install Python dependencies"
         run: |
-          sudo apt install graphviz
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install tox tox-gh
       - name: "Setup tests"
         run: tox -vv --notest
       - name: "Run tests"
         run: tox --skip-pkg-install
+


### PR DESCRIPTION
The Windows runs currently have some failing tests, so they're configured to fail without aborting the workflow.

(I'll have to check whether the Windows failures interfere with PR mergeability. They may need to be adjusted to actually fake-pass, instead of simply ignoring the failures.)

#### Windows failing tests
There are a few files in `test/charts/` that Windows `dot.exe` (from graphviz 9.0.0, installed via Chocolatey) fails on. 

1. `b51.dot` is the one that shows up in the current CI. (It's the first failure in that directory, and the big monolithic test case stops there.) It fails with a hexdigest mismatch — `dot.exe` just seems to render it a bit differently.
1. `b53.dot`, same as `b51` just renders differently and triggers a digest mismatch.
1. `proc3D.dot` is a third digest mismatch.
1. `b993.dot` is different, it never actually renders at all. The graph data starts with the line `diGraph G{`, and that triggers a syntax error. It seems that Windows `dot.exe` is case-sensitive, ironically, so it doesn't recognize `diGraph` as a synonym for `digraph`.

(Note: One effect of merging #308 would be that all tests are run and every failure reported, rather than skipping all the rest of the tests in the directory at the first sign of failure.)