### PR TITLE
fix: added an optional space literal after "equals" inside a_list

### DIFF
--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -426,7 +426,7 @@ def graph_definition():
 
         node_id = ID + Optional(port)
         a_list = OneOrMore(
-            ID + Optional(equals + righthand_id) + Optional(comma.suppress())
+            ID + Optional(equals + Optional(Literal(" ")) + righthand_id) + Optional(comma.suppress())
         ).setName("a_list")
 
         attr_list = OneOrMore(


### PR DESCRIPTION
# Description of My Problem
For this piece of code, pydot worked normally:
```python
import pydot
from typing import List

dot_string = """digraph "my_graph" {
    "25" [label=<(METHOD_RETURN,int)<SUB>4</SUB>> ]
    "14" [label=<(insert,maps.insert(&quot;version&quot;, version.get_value()))<SUB>7</SUB>> ]
    "14" -> "25"  [ label="maps.insert"] 
}
"""

g: List[pydot.Dot] = pydot.graph_from_dot_data(dot_string)
```
But for the code below
```python
import pydot
from typing import List

dot_string = """digraph "my_graph" {
    "25" [label=<(METHOD_RETURN,int)<SUB>4</SUB>> ]
    "14" [label= <(insert,maps.insert(&quot;version&quot;, version.get_value()))<SUB>7</SUB>> ]
    "14" -> "25"  [ label="maps.insert"] 
}
"""

g: List[pydot.Dot] = pydot.graph_from_dot_data(dot_string)
```

Pydot raised such an error:

```shell
    "14" [label= <(insert,maps.insert(&quot;version&quot;, version.get_value()))<SUB>7</SUB>> ]
         ^
Expected graph_stmt, found '['  (at char 82), (line:3, col:10)
```

The problem is due to that the node `"14"` of wrong code had got an redundant space after `=` .  As this kind of redundant spaces may be generated by some tool, and actually this piece of dot code was excerpted from a dot file generated by [Joern](https://joern.io/), a code analysis tool.

# My Fix

I just added an optional space literal after `equals`.