### PR TITLE
Set pyparsing>=3.0.9 in depencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 license = {file = "LICENSE"}
 requires-python = ">= 3.7"
 dependencies = [
-  'pyparsing>=3'
+  'pyparsing>=3.0.9'
 ]
 authors = [
   {name = "Ero Carrera", email = "ero.carrera@gmail.com"},


### PR DESCRIPTION
Pydot use `BasicMultilingualPlane` from `pyparsing`, that was added only in [3.0.9](https://github.com/pyparsing/pyparsing/blob/2a1a8e8f4beee7fd120c3fdc1a48725b77e263c2/CHANGES#L253)
https://github.com/pydot/pydot/blob/28f0fe442b5b11c9ed2255fe79b349f48c14a441/src/pydot/dot_parser.py#L395


With `pyparsing>=3,<3.0.9` raises an exception: 
```python
AttributeError: type object 'pyparsing_unicode' has no attribute 'BasicMultilingualPlane'
```