### PR TITLE
Tests: Fix b993.dot mixed-case

### DIFF
--- a/test/graphs/b993.dot
+++ b/test/graphs/b993.dot
@@ -1,4 +1,4 @@
-diGraph G{
+digraph G{
 graph [charset="utf8"]
 1[label="Umlaut"];
 2[label="ü"];


### PR DESCRIPTION
Currently the only thing this is testing is whether or not the local `dot` executable was correctly built case-insensitive, which isn't really something pydot should be concerning itself with.

This will make the test consistently pass on Windows.