### PR TITLE
CI: Export failed images as build artifact

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
         system:
           - {os: ubuntu, can-fail: false}
           - {os: windows, can-fail: true}
-          - {os: macos, can-fail: false}
+          - {os: macos, can-fail: true}
         python-version:
           - "3.12"
           - "3.11"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,15 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pip"
+      - name: "Set up TEST_ERROR_DIR"
+        shell: bash
+        run: |
+          mkdir test_errors
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "TEST_ERROR_DIR=$(cygpath -w $(realpath ./test_errors))" >> "$GITHUB_ENV"
+          else
+            echo "TEST_ERROR_DIR=$(pwd -P)/test_errors" >> "$GITHUB_ENV"
+          fi
       - name: "Install graphviz (Linux)"
         if: runner.os == 'linux'
         run: sudo apt install graphviz
@@ -64,4 +73,13 @@ jobs:
         run: tox -vv --notest
       - name: "Run tests"
         run: tox --skip-pkg-install
-
+      - name: "Prepare error artifacts"
+        if: ${{ failure() }}
+        run: cp test/compare_images.sh "${{ env.TEST_ERROR_DIR }}"
+      - name: "Publish error artifacts"
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-errors-${{ runner.os }}-${{ matrix.python-version }}
+          path: ${{ env.TEST_ERROR_DIR }}
+          if-no-files-found: ignore

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ env_list =
 extras = tests
 package = wheel
 wheel_build_env = .pkg
+pass_env =
+    TEST_ERROR_DIR
 commands = unittest-parallel --level test -vv
 
 [testenv:black]

--- a/test/compare_images.sh
+++ b/test/compare_images.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for dir in */; do
+    magick composite $dir/err_pydot.jpeg \
+        -compose difference $dir/err_graphviz.jpeg \
+        $dir/err_difference.png
+done

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -24,6 +24,7 @@ if sys.version_info >= (3, 8):
 else:
     from ._functools import cached_property
 
+TEST_ERROR_DIR = os.getenv("TEST_ERROR_DIR", None)
 
 TEST_PROGRAM = "dot"
 TESTS_DIR_1 = "my_tests"
@@ -94,6 +95,25 @@ def _load_test_cases(casedir):
         return fname.removesuffix(".dot")
 
     return [(_case_name(dot_file), dot_file, path) for dot_file in dot_files]
+
+
+def _compare_images(fname: str, pydot: RenderResult, gv: RenderResult) -> bool:
+    """Compare two RenderResult objects for the named test.
+
+    If the images differ and a ``TEST_ERROR_DIR`` has been provided, create
+    a subdir for the test and dump both images there for examination."""
+    if pydot.checksum == gv.checksum:
+        return True
+    if TEST_ERROR_DIR is not None:
+        dirname = fname.replace(".", "_")
+        out_dir = os.path.join(os.path.normpath(TEST_ERROR_DIR), dirname)
+        os.makedirs(out_dir)
+        pydot_path = os.path.join(out_dir, "err_pydot.jpeg")
+        gv_path = os.path.join(out_dir, "err_graphviz.jpeg")
+        with open(pydot_path, "wb") as p, open(gv_path, "wb") as g:
+            p.write(pydot.data)
+            g.write(gv.data)
+    return False
 
 
 class PydotTestCase(unittest.TestCase):
@@ -422,11 +442,11 @@ class TestShapeFiles(PydotTestCase):
         g.set_shape_files(pngs)
 
         rendered = RenderResult(g.create(format="jpe"))
-        original = Renderer.graphviz(dot_file, encoding="ascii")
-        if rendered.checksum != original.checksum:
+        graphviz = Renderer.graphviz(dot_file, encoding="ascii")
+        if not _compare_images("from-past-to-future", rendered, graphviz):
             raise AssertionError(
                 "from-past-to-future.dot: "
-                f"{rendered.checksum} != {original.checksum} "
+                f"{rendered.checksum} != {graphviz.checksum} "
                 "(found pydot vs graphviz difference)"
             )
 
@@ -440,7 +460,7 @@ class RenderedTestCase(PydotTestCase):
             s = f.read()
         estimate = chardet.detect(s)
         encoding = encodings.get(fname, estimate["encoding"])
-        pydot = Renderer.pydot(
+        rendered = Renderer.pydot(
             fpath,
             encoding,
         )
@@ -448,15 +468,9 @@ class RenderedTestCase(PydotTestCase):
             fpath,
             encoding,
         )
-        if pydot.checksum != graphviz.checksum:
-            # In case of error, save both images locally for inspection
-            now = datetime.datetime.now().strftime("%H_%M_%S")
-            with open(f"err_{fname}_pydot_{now}.jpeg", "wb") as f:
-                f.write(pydot.data)
-            with open(f"err_{fname}_graphviz_{now}.jpeg", "wb") as f:
-                f.write(graphviz.data)
+        if not _compare_images(fname, rendered, graphviz):
             raise AssertionError(
-                f"{fname}: {pydot.checksum} != {graphviz.checksum} "
+                f"{fname}: {rendered.checksum} != {graphviz.checksum} "
                 "(found pydot vs graphviz difference)"
             )
 


### PR DESCRIPTION
- Make saving of images from failed tests conditional on setting an envvar `TEST_ERROR_DIR` to a path in which to store them.
- Modify image storage to use predictable names inside uniquely named subdirs.
- Provide a script to create image diffs with ImageMagick.
- Export failed-test dirs and comparison script as an artifact from failed CI runs.