### PR TITLE
Disable certain tests temporarily on Windows

### DIFF
--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -392,6 +392,8 @@ class TestGraphAPI(PydotTestCase):
         self.assertIsInstance(pydot.__version__, str)
 
 
+# TODO: Remove skipIf when graphviz 10.0.1 is available
+@unittest.skipIf(sys.platform.startswith("win"), "Unreliable on Windows")
 class TestShapeFiles(PydotTestCase):
     shapefile_dir = os.path.join(_test_root, "from-past-to-future")
 
@@ -472,8 +474,19 @@ class TestMyRegressions(RenderedTestCase):
 class TestGraphvizRegressions(RenderedTestCase):
     """Perform regression tests in graphs dir."""
 
+    _skip_on_win = [
+        "b51.dot",
+        "b53.dot",
+        "clust2.dot",
+        "proc3d.dot",
+    ]
+
     @parameterized.expand(functools.partial(_load_test_cases, TESTS_DIR_2))
     def test_regression(self, _, fname, path):
+        if sys.platform.startswith("win") and fname in self._skip_on_win:
+            # TODO: remove when graphviz 10.0.1 is available
+            self.skipTest(f"{fname} results are unpredictable on Windows")
+            return
         self._render_and_compare_dot_file(path, fname)
 
 


### PR DESCRIPTION
These tests render unpredictably in graphviz `dot.exe` until version 10.0.1. See https://gitlab.com/graphviz/graphviz/-/issues/2510

(Note: I've made this Windows-only for now, as that's the platform where tests fail _reliably_. macOS is exhibiting **occasional** failures as well, but we don't have enough CI runs yet to be sure which tests fail there.

(Also, I expect Homebrew will be updated to graphviz 10.0.1 long before Chocolatey will, so the macOS problem should solve itself soon enough.)