### PR TITLE
Also disable from-past-to-future test on macOS

### DIFF
--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -413,7 +413,10 @@ class TestGraphAPI(PydotTestCase):
 
 
 # TODO: Remove skipIf when graphviz 10.0.1 is available
-@unittest.skipIf(sys.platform.startswith("win"), "Unreliable on Windows")
+@unittest.skipIf(
+    sys.platform.startswith("win") or sys.platform == "darwin",
+    "Unreliable on Windows and macOS",
+)
 class TestShapeFiles(PydotTestCase):
     shapefile_dir = os.path.join(_test_root, "from-past-to-future")
 


### PR DESCRIPTION
It [looks like](https://github.com/pydot/pydot/actions/runs/7907224462/job/21583793542?pr=318) the `from-past-to-future.dot` file is also sometimes failing on macOS, so disable it there as well.
