### PR TITLE
Fix quoting of attribute values

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -285,11 +285,11 @@ class frozendict(dict):
 
 dot_keywords = ["graph", "subgraph", "digraph", "node", "edge", "strict"]
 
-id_re_alpha_nums = re.compile("^[_a-zA-Z][a-zA-Z0-9_,]*$", re.UNICODE)
+id_re_alpha_nums = re.compile(r"^[_a-zA-Z][a-zA-Z0-9_\.]*$", re.UNICODE)
 id_re_alpha_nums_with_ports = re.compile(
-    '^[_a-zA-Z][a-zA-Z0-9_,:"]*[a-zA-Z0-9_,"]+$', re.UNICODE
+    r'^[_a-zA-Z][a-zA-Z0-9_\.:"]*[a-zA-Z0-9_\."]+$', re.UNICODE
 )
-id_re_num = re.compile("^[0-9,]+$", re.UNICODE)
+id_re_num = re.compile(r"^[0-9\.]+$", re.UNICODE)
 id_re_with_port = re.compile("^([^:]*):([^:]*)$", re.UNICODE)
 id_re_dbl_quoted = re.compile('^".*"$', re.S | re.UNICODE)
 id_re_html = re.compile("^<.*>$", re.S | re.UNICODE)
@@ -314,8 +314,12 @@ def needs_quotes(s):
     if s in dot_keywords:
         return False
 
-    chars = [ord(c) for c in s if ord(c) > 0x7F or ord(c) == 0]
-    if chars and not id_re_dbl_quoted.match(s) and not id_re_html.match(s):
+    has_high_chars = any([ord(c) > 0x7F or ord(c) == 0 for c in s])
+    if (
+        has_high_chars
+        and not id_re_dbl_quoted.match(s)
+        and not id_re_html.match(s)
+    ):
         return True
 
     for test_re in [

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -299,6 +299,26 @@ class TestGraphAPI(PydotTestCase):
             self.graph_directed.get_nodes()[0].to_string(), "node [shape=box];"
         )
 
+    def test_comma_separated_attribute_values_to_string(self):
+        self._reset_graphs()
+        self.graph_directed.add_node(
+            pydot.Node("node", color="green", style="rounded,filled")
+        )
+        self.assertEqual(
+            self.graph_directed.get_nodes()[0].to_string(),
+            'node [color=green, style="rounded,filled"];',
+        )
+
+    def test_attribute_string_values_quoting(self):
+        self._reset_graphs()
+        self.graph_directed.add_node(
+            pydot.Node("node", length=1.234, size="2.345", radius="9,876")
+        )
+        self.assertEqual(
+            self.graph_directed.get_nodes()[0].to_string(),
+            'node [length=1.234, radius="9,876", size=2.345];',
+        )
+
     def test_names_of_a_thousand_nodes(self):
         self._reset_graphs()
         names = {"node_%05d" % i for i in range(10**3)}


### PR DESCRIPTION
The `needs_quotes()` and `quote_if_necessary()` logic for handling numeric values and/or values containing commas seems to have been written based on a comma-decimal numeric format, leaving strings like `"1,234"` unquoted while forcing quotes around strings like `"1.234"`.

From a pydot perspective, that's exactly backwards, since attributes are comma-separated so all values containing commas should be quoted. This also bled into things like `style` values containing multiple classes (e.g. `"rounded,filled"`), which would be left unquoted.

This PR replaces the `'[0-9,]*'` numeric regular expressions with `r'[0-9\.]*'`, and equivalent for the alphanumeric regexps, so that values like `"1.234"` are left unquoted, but `"1,234"` and `"rounded,filled"` will always be quoted.

A second commit adds a couple of additional unit tests to verify the new behavior.

Fixes #301 
