### PR TITLE
Tests: Reenable flaky tests on Windows & macOS

### DIFF
--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -432,11 +432,6 @@ class TestGraphAPI(PydotTestCase):
         self.assertIsInstance(pydot.__version__, str)
 
 
-# TODO: Remove skipIf when graphviz 10.0.1 is available
-@unittest.skipIf(
-    sys.platform.startswith(("win", "darwin")),
-    "Unreliable on Windows and macOS",
-)
 class TestShapeFiles(PydotTestCase):
     shapefile_dir = os.path.join(_test_root, "from-past-to-future")
 
@@ -511,23 +506,8 @@ class TestMyRegressions(RenderedTestCase):
 class TestGraphvizRegressions(RenderedTestCase):
     """Perform regression tests in graphs dir."""
 
-    _skip_on_win_mac = [
-        "b51.dot",
-        "b53.dot",
-        "clust2.dot",
-        "proc3d.dot",
-    ]
-
     @parameterized.expand(functools.partial(_load_test_cases, TESTS_DIR_2))
     def test_regression(self, _, fname, path):
-        if (
-            sys.platform.startswith(("win", "darwin"))
-            and fname in self._skip_on_win_mac
-        ):
-            # TODO: remove when graphviz 10.0.1 is available
-            self.skipTest(
-                f"{fname} results are unpredictable on Windows and macOS"
-            )
         self._render_and_compare_dot_file(path, fname)
 
 


### PR DESCRIPTION
graphviz-10.0.1 is now available through Chocolatey & Homebrew.

(I know [I predicted](https://github.com/pydot/pydot/pull/317#issue-2134839664) Chocolatey would lag behind Homebrew and be the last ones to update, when it turned out the other way around. That's because I put my finger on the scale: [I reported](https://github.com/chocolatey-community/chocolatey-packages/issues/2432) the package as out-of-date to Chocolatey, _and_ [I fixed](https://gitlab.com/graphviz/graphviz.gitlab.io/-/merge_requests/653) the sorting issues on the download page that were hiding the new release way at the bottom of the list, so both systems' auto-updaters were able to find the new release.)

Regardless, they've both now gotten there, and 10.0.1 should contain the fixes that make our flaky tests no longer flaky, so reenabling them on both platforms.