### PR TITLE
CI: Add --ignore-http-cache to 'choco install'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -61,7 +61,7 @@ jobs:
         run: sudo apt install graphviz
       - name: "Install graphviz (Windows)"
         if: runner.os == 'windows'
-        run: choco install graphviz
+        run: choco install graphviz --ignore-http-cache
       - name: "Install graphviz (macOS)"
         if: runner.os == 'macos'
         run: brew install graphviz


### PR DESCRIPTION
It [looks like](https://github.com/chocolatey/choco/issues/3193) adding the `--ignore-http-cache` argument to `choco install` will (or at least _may_) help avoid outdated-version issues like the ones we were seeing in #324 immediately after a new `graphviz` package was released to Chocolatey.