### PR TITLE
Replace all remaining %-substitution and .format() calls with f-strings

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -18,7 +18,7 @@ except Exception as e:
     warnings.warn(
         "`pydot` could not import `dot_parser`, "
         "so `pydot` will be unable to parse DOT files. "
-        "The error was:  {e}".format(e=e)
+        f"The error was:  {e}"
     )
 
 
@@ -280,7 +280,8 @@ class frozendict(dict):
             return h
 
     def __repr__(self):
-        return "frozendict(%s)" % dict.__repr__(self)
+        dict_repr = dict.__repr__(self)
+        return f"frozendict({dict_repr})"
 
 
 dot_keywords = ["graph", "subgraph", "digraph", "node", "edge", "strict"]
@@ -457,8 +458,8 @@ def graph_from_adjacency_matrix(matrix, node_prefix="", directed=False):
             if e:
                 graph.add_edge(
                     Edge(
-                        "%s%s" % (node_prefix, node_orig),
-                        "%s%s" % (node_prefix, node_dest),
+                        f"{node_prefix}{node_orig}",
+                        f"{node_prefix}{node_dest}",
                     )
                 )
             node_dest += 1
@@ -494,8 +495,8 @@ def graph_from_incidence_matrix(matrix, node_prefix="", directed=False):
         if len(nodes) == 2:
             graph.add_edge(
                 Edge(
-                    "%s%s" % (node_prefix, abs(nodes[0])),
-                    "%s%s" % (node_prefix, nodes[1]),
+                    f"{node_prefix}{abs(nodes[0])}",
+                    f"{node_prefix}{nodes[1]}",
                 )
             )
 
@@ -687,7 +688,7 @@ class Node(Common):
             if value == "":
                 value = '""'
             if value is not None:
-                node_attr.append("%s=%s" % (attr, quote_if_necessary(value)))
+                node_attr.append(f"{attr}={quote_if_necessary(value)}")
             else:
                 node_attr.append(attr)
 
@@ -868,7 +869,7 @@ class Edge(Common):
             if value == "":
                 value = '""'
             if value is not None:
-                edge_attr.append("%s=%s" % (attr, quote_if_necessary(value)))
+                edge_attr.append(f"{attr}={quote_if_necessary(value)}")
             else:
                 edge_attr.append(attr)
 
@@ -939,11 +940,8 @@ class Graph(Common):
 
             if graph_type not in ["graph", "digraph"]:
                 raise pydot.Error(
-                    (
-                        'Invalid type "{t}". '
-                        "Accepted graph types are: "
-                        "graph, digraph"
-                    ).format(t=graph_type)
+                    f'Invalid type "{graph_type}". '
+                    "Accepted graph types are: graph, digraph"
                 )
 
             self.obj_dict["name"] = quote_if_necessary(graph_name)
@@ -1396,9 +1394,8 @@ class Graph(Common):
             "show_keyword", True
         ):
             graph_type = ""
-        s = "{type} {name} {{\n".format(
-            type=graph_type, name=self.obj_dict["name"]
-        )
+        graph_name = self.obj_dict["name"]
+        s = f"{graph_type} {graph_name} {{\n"
         graph.append(s)
 
         for attr in sorted(self.obj_dict["attributes"]):
@@ -1407,7 +1404,7 @@ class Graph(Common):
                 if val == "":
                     val = '""'
                 if val is not None:
-                    graph.append("%s=%s" % (attr, quote_if_necessary(val)))
+                    graph.append(f"{attr}={quote_if_necessary(val)}")
                 else:
                     graph.append(attr)
 
@@ -1761,7 +1758,7 @@ class Dot(Graph):
             f.write(f_data)
             f.close()
 
-        arguments = ["-T{}".format(format)] + args + [tmp_name]
+        arguments = [f"-T{format}"] + args + [tmp_name]
 
         try:
             stdout_data, stderr_data, process = call_graphviz(
@@ -1772,7 +1769,7 @@ class Dot(Graph):
         except OSError as e:
             if e.errno == errno.ENOENT:
                 args = list(e.args)
-                args[1] = '"{prog}" not found in path.'.format(prog=prog)
+                args[1] = f'"{prog}" not found in path.'
                 raise OSError(*args)
             else:
                 raise
@@ -1784,25 +1781,15 @@ class Dot(Graph):
         os.unlink(tmp_name)
 
         if process.returncode != 0:
-            message = (
-                '"{prog}" with args {arguments} returned code: {code}\n\n'
-                "stdout, stderr:\n {out}\n{err}\n"
-            ).format(
-                prog=prog,
-                arguments=arguments,
-                code=process.returncode,
-                out=stdout_data,
-                err=stderr_data,
+            code = process.returncode
+            print(
+                f'"{prog}" with args {arguments} returned code: {code}\n\n'
+                f"stdout, stderr:\n {stdout_data}\n{stderr_data}\n"
             )
-            print(message)
 
         assert (
             process.returncode == 0
-        ), '"{prog}" with args {arguments} returned code: {code}'.format(
-            prog=prog,
-            arguments=arguments,
-            code=process.returncode,
-        )
+        ), f'"{prog}" with args {arguments} returned code: {process.returncode}'
 
         return stdout_data
 

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -50,7 +50,8 @@ class P_AttrList(object):
             self.attrs[attrname] = attrvalue
 
     def __repr__(self):
-        return "%s(%r)" % (self.__class__.__name__, self.attrs)
+        name = self.__class__.__name__
+        return f"{name}({self.attrs!r})"
 
 
 class DefaultStatement(P_AttrList):
@@ -59,11 +60,8 @@ class DefaultStatement(P_AttrList):
         self.attrs = attrs
 
     def __repr__(self):
-        return "%s(%s, %r)" % (
-            self.__class__.__name__,
-            self.default_type,
-            self.attrs,
-        )
+        name = self.__class__.__name__
+        return f"{name}({self.default_type}, {self.attrs!r})"
 
 
 top_graphs = list()
@@ -110,9 +108,7 @@ def push_top_graph_stmt(s, loc, toks):
             add_elements(g, element)
 
         else:
-            raise ValueError(
-                "Unknown element statement: {s}".format(s=element)
-            )
+            raise ValueError(f"Unknown element statement: {element}")
 
     for g in top_graphs:
         update_parent_graph_hierarchy(g)
@@ -215,18 +211,14 @@ def add_elements(
 
             else:
                 raise ValueError(
-                    "Unknown DefaultStatement: {s}".format(
-                        s=element.default_type
-                    )
+                    f"Unknown DefaultStatement: {element.default_type}"
                 )
 
         elif isinstance(element, P_AttrList):
             g.obj_dict["attributes"].update(element.attrs)
 
         else:
-            raise ValueError(
-                "Unknown element statement: {s}".format(s=element)
-            )
+            raise ValueError(f"Unknown element statement: {element}")
 
 
 def push_graph_stmt(s, loc, toks):
@@ -265,7 +257,7 @@ def push_default_stmt(s, loc, toks):
     if default_type in ["graph", "node", "edge"]:
         return DefaultStatement(default_type, attrs)
     else:
-        raise ValueError("Unknown default statement: {s}".format(s=toks))
+        raise ValueError(f"Unknown default statement: {toks}")
 
 
 def push_attr_list(s, loc, toks):
@@ -339,9 +331,7 @@ def push_edge_stmt(s, loc, toks):
             n_prev = n_next[0] + n_next_port
     else:
         raise Exception(
-            "Edge target {r} with type {s} unsupported.".format(
-                r=toks[2][0], s=type(toks[2][0])
-            )
+            f"Edge target {toks[2][0]} with type {type(toks[2][0])} unsupported."
         )
 
     return e

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -236,21 +236,18 @@ class TestGraphAPI(PydotTestCase):
         ]
         expected_concat = observed_concat = ""
         for graph_type, simplify, expected in test_combinations:
-            expected_concat += "graph_type %s, simplify %s: %s\n" % (
-                graph_type,
-                simplify,
-                expected,
+            expected_concat += (
+                f"graph_type {graph_type}, simplify {simplify}: {expected}\n"
             )
             g.set_type(graph_type)
             g.set_simplify(simplify)
             try:
                 observed = " ".join(g.to_string().split())
             except (NameError, TypeError) as e:
-                observed = "%s: %s" % (type(e).__name__, e)
-            observed_concat += "graph_type %s, simplify %s: %s\n" % (
-                graph_type,
-                simplify,
-                observed,
+                type_name = type(e).__name__
+                observed = f"{type_name}: {e}"
+            observed_concat += (
+                f"graph_type {graph_type}, simplify {simplify}: {observed}\n"
             )
         self.maxDiff = None
         self.assertMultiLineEqual(expected_concat, observed_concat)
@@ -321,7 +318,7 @@ class TestGraphAPI(PydotTestCase):
 
     def test_names_of_a_thousand_nodes(self):
         self._reset_graphs()
-        names = {"node_%05d" % i for i in range(10**3)}
+        names = {f"node_{i:05d}" for i in range(10**3)}
         for name in names:
             self.graph_directed.add_node(pydot.Node(name, label=name))
 
@@ -528,5 +525,5 @@ def parse_args():
 
 if __name__ == "__main__":
     parse_args()
-    print("The tests are using `pydot` from:  {pd}".format(pd=pydot))
+    print(f"The tests are using `pydot` from:  {pydot}")
     unittest.main(verbosity=2)


### PR DESCRIPTION
With Python 3.6 and higher, there are few reasons to ever use `%`-substitution or explicit `.format()` calls, and lots of reasons to prefer `f`-strings instead.

(When Python 3.7 support is dropped, we could even take advantage of the final improvement older Python versions lack: [the `=` specifier](https://docs.python.org/3/whatsnew/3.8.html#f-strings-support-for-self-documenting-expressions-and-debugging), which allows for self-documenting string generation/output:

```python
>>> my_variable = 27.4
>>> print(f"{my_variable=}")
my_variable=27.4
```
...Which would likely be useful in `test_pydot.py`, if not the main package code. But 3.7 doesn't support that syntax.)