### PR TITLE
Enhance compare_images.py with animation

### DIFF
--- a/test/compare_images.sh
+++ b/test/compare_images.sh
@@ -4,4 +4,7 @@ for dir in */; do
     magick composite $dir/err_pydot.jpeg \
         -compose difference $dir/err_graphviz.jpeg \
         $dir/err_difference.png
+    magick convert -delay 100 $dir/err_pydot.jpeg \
+	-delay 100 $dir/err_graphviz.jpeg \
+	$dir/anim_difference.gif
 done


### PR DESCRIPTION
In addition to the image-difference comparison already implemented, have `compare_images.sh` (which is included in downloads of comparison error archives from the CI system, and only run by the downloader) also create a looping animated GIF showing the two images one after the other, which is turning out to be a superior comparison method.

(The animation will use a 1 fps frame rate, easier on the eyes than the 10 fps comparisons I'd previously made.)