### PR TITLE
Dependencies: remove old requirements.txt files

### DIFF
--- a/requirements-conda.txt
+++ b/requirements-conda.txt
@@ -1,3 +1,0 @@
-graphviz >=2.38.0
-pyparsing >=3
-chardet

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-# dev
-chardet


### PR DESCRIPTION
Because there is `pyproject.toml`, we don't need `requirements.txt` anymore.