### PR TITLE
Drop Python 3.7 from CI matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,7 +40,6 @@ jobs:
           - "3.10"
           - "3.9"
           - "3.8"
-          - "3.7"
 
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
It's EOL as of 2023-06-27, and causes problems for MacOS jobs running on Apple Silicon, for which there is no version available.