### PR TITLE
Quote graph/node name when setting it

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -659,7 +659,7 @@ class Node(Common):
 
     def set_name(self, node_name):
         """Set the node's name."""
-        self.obj_dict["name"] = node_name
+        self.obj_dict["name"] = quote_if_necessary(node_name)
 
     def get_name(self):
         """Get the node's name."""

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1042,7 +1042,7 @@ class Graph(Common):
 
     def set_name(self, graph_name):
         """Set the graph's name."""
-        self.obj_dict["name"] = graph_name
+        self.obj_dict["name"] = quote_if_necessary(graph_name)
 
     def get_name(self):
         """Get the graph's name."""


### PR DESCRIPTION
This would avoid the graph breaking when setting the node name to for eg. something with spaces or slashes.

## Steps to reproduce:

```python
import pydot

graph = pydot.Graph()
graph.set_name("foo bar")
print(graph.to_string())
```

```console
$ python3 x.py
digraph foo bar {
}

$ python3 x.py | dot -Tpng
Error: <stdin>: syntax error in line 1 near 'bar'
```

### After fix:

```console
$ python3 x.py
digraph "foo bar" {
}
```