### PR TITLE
Move get_top_graph_type() to Common

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -569,6 +569,22 @@ class Common:
     def get_parent_graph(self):
         return self.obj_dict.get("parent_graph", None)
 
+    def get_top_graph_type(self):
+        """Find the topmost parent graph type for the current object."""
+        if isinstance(self, Graph):
+            parent = self
+        else:
+            parent = self.get_parent_graph()
+        if parent is None:
+            return None
+        while True:
+            parent_ = parent.get_parent_graph()
+            if parent_ == parent:
+                break
+            parent = parent_
+
+        return parent.obj_dict["type"]
+
     def set(self, name, value):
         """Set an attribute value by name.
 
@@ -788,7 +804,7 @@ class Edge(Common):
         if not isinstance(edge, Edge):
             raise pydot.Error("Can not compare an edge to a non-edge object.")
 
-        if self.get_parent_graph().get_top_graph_type() == "graph":
+        if self.get_top_graph_type() == "graph":
             # If the graph is undirected, the edge has neither
             # source nor destination.
             #
@@ -849,13 +865,8 @@ class Edge(Common):
         else:
             edge = [src]
 
-        if (
-            self.get_parent_graph()
-            and self.get_parent_graph().get_top_graph_type()
-            and self.get_parent_graph().get_top_graph_type() == "digraph"
-        ):
+        if self.get_top_graph_type() == "digraph":
             edge.append("->")
-
         else:
             edge.append("--")
 
@@ -967,16 +978,6 @@ class Graph(Common):
 
     def get_graph_type(self):
         return self.obj_dict["type"]
-
-    def get_top_graph_type(self):
-        parent = self
-        while True:
-            parent_ = parent.get_parent_graph()
-            if parent_ == parent:
-                break
-            parent = parent_
-
-        return parent.obj_dict["type"]
 
     def set_graph_defaults(self, **attrs):
         self.add_node(Node("graph", **attrs))

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -571,10 +571,7 @@ class Common:
 
     def get_top_graph_type(self):
         """Find the topmost parent graph type for the current object."""
-        if isinstance(self, Graph):
-            parent = self
-        else:
-            parent = self.get_parent_graph()
+        parent = self.get_parent_graph()
         if parent is None:
             return None
         while True:


### PR DESCRIPTION
A quick fix I noticed while working on #339.

By making `get_top_graph_type()` a method of all classes, and handling the lookup of parent graphs there, the code no longer needs to do laborious checks on the existence of a parent graph, and the existence of the parent graph's `get_top_graph_type()` method, just to be able to call it.

The method can now return `None`, if the current instance has no parent graph, but that's fine as we always compare the return value to some string. `None == "graph"` or `None == "digraph"` will always evaluate to `False`.