### PR TITLE
Use ruff format --diff in CI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ commands = unittest-parallel --level test -vv
 [testenv:ruff]
 deps = ruff==0.4.8
 commands = 
-    ruff format --check .
+    ruff format --diff .
     ruff check .
 
 # For tox-gh


### PR DESCRIPTION
It'll still register as a failure, but at least whatever problems it has with the code will be visible.