### PR TITLE
Don't use `sorted()` on attributes in `to_string()` methods

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -700,7 +700,7 @@ class Node(Common):
 
         node_attr = []
 
-        for attr in sorted(self.obj_dict["attributes"]):
+        for attr in self.obj_dict["attributes"]:
             value = self.obj_dict["attributes"][attr]
             if value == "":
                 value = '""'
@@ -876,7 +876,7 @@ class Edge(Common):
 
         edge_attr = []
 
-        for attr in sorted(self.obj_dict["attributes"]):
+        for attr in self.obj_dict["attributes"]:
             value = self.obj_dict["attributes"][attr]
             if value == "":
                 value = '""'
@@ -1400,7 +1400,7 @@ class Graph(Common):
         s = f"{graph_type} {graph_name} {{\n"
         graph.append(s)
 
-        for attr in sorted(self.obj_dict["attributes"]):
+        for attr in self.obj_dict["attributes"]:
             if self.obj_dict["attributes"].get(attr, None) is not None:
                 val = self.obj_dict["attributes"].get(attr)
                 if val == "":

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -143,7 +143,7 @@ class TestGraphAPI(PydotTestCase):
         g.add_node(node)
         node.set("label", "mine")
         s = g.to_string()
-        expected = "digraph G {\nlegend [label=mine, shape=box];\n}\n"
+        expected = "digraph G {\nlegend [shape=box, label=mine];\n}\n"
         assert s == expected
 
     def test_attribute_with_implicit_value(self):
@@ -308,7 +308,7 @@ class TestGraphAPI(PydotTestCase):
         )
         self.assertEqual(
             self.graph_directed.get_nodes()[0].to_string(),
-            'node [length=1.234, radius="9,876", size=2.345];',
+            'node [length=1.234, size=2.345, radius="9,876"];',
         )
 
     def test_names_of_a_thousand_nodes(self):


### PR DESCRIPTION
Fix https://github.com/pydot/pydot/issues/358 (unnecessary sorting of attributes in `to_string()` methods)