### PR TITLE
Add ruff to the 'tests' extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dev = [
 tests = [
   'chardet',
   'parameterized',
+  'ruff',
   'tox',
   'unittest-parallel',
 ]


### PR DESCRIPTION
So that it's available after running `pip install -e '.[tests]'`