### PR TITLE
Split attribute quoting from ID quoting, rewrite attribute formatting, store names unquoted

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -291,14 +291,11 @@ class frozendict(dict):
 def make_quoted(s):
     """Transform a string into a quoted string, escaping specials."""
     replace = {
-        '"': r"\"",
-        "\n": r"\n",
-        "\r": r"\r",
+        ord('"'): r"\"",
+        ord("\n"): r"\n",
+        ord("\r"): r"\r",
     }
-    s.translate(replace)
-    for a, b in replace.items():
-        s = s.replace(a, b)
-    return rf'"{s}"'
+    return rf'"{s.translate(replace)}"'
 
 
 dot_keywords = ["graph", "subgraph", "digraph", "node", "edge", "strict"]
@@ -678,7 +675,8 @@ class Common:
     def attrs_string(self, prefix=""):
         """Format the current attributes list for output.
 
-        The `prefix` string will be prepended iff text is generated."""
+        The `prefix` string will be prepended if and only if some
+        output is generated."""
         attrs = self.formatted_attr_list()
         if not attrs:
             return ""

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -288,19 +288,49 @@ class frozendict(dict):
         return f"frozendict({dict_repr})"
 
 
+def make_quoted(s):
+    """Transform a string into a quoted string, escaping specials."""
+    replace = {
+        '"': r"\"",
+        "\n": r"\n",
+        "\r": r"\r",
+    }
+    s.translate(replace)
+    for a, b in replace.items():
+        s = s.replace(a, b)
+    return rf'"{s}"'
+
+
 dot_keywords = ["graph", "subgraph", "digraph", "node", "edge", "strict"]
 
-id_re_alpha_nums = re.compile(r"^[_a-zA-Z][a-zA-Z0-9_\.]*$", re.UNICODE)
+re_all_numeric = re.compile(r"^[0-9\.]+$")
+re_dbl_quoted = re.compile(r'^".*"$', re.S)
+re_html = re.compile(r"^<.*>$", re.S)
+
+id_re_alpha_nums = re.compile(r"^[_a-zA-Z][a-zA-Z0-9_\.]*$")
 id_re_alpha_nums_with_ports = re.compile(
-    r'^[_a-zA-Z][a-zA-Z0-9_\.:"]*[a-zA-Z0-9_\."]+$', re.UNICODE
+    r'^[_a-zA-Z][a-zA-Z0-9_\.:"]*[a-zA-Z0-9_\."]+$'
 )
-id_re_num = re.compile(r"^[0-9\.]+$", re.UNICODE)
-id_re_with_port = re.compile("^([^:]*):([^:]*)$", re.UNICODE)
-id_re_dbl_quoted = re.compile('^".*"$', re.S | re.UNICODE)
-id_re_html = re.compile("^<.*>$", re.S | re.UNICODE)
+id_re_with_port = re.compile(r"^([^:]*):([^:]*)$")
 
 
-def needs_quotes(s):
+def any_needs_quotes(s):
+    """Determine if a string needs to be quoted.
+
+    Returns True, False, or None if the result is indeterminate.
+    """
+    has_high_chars = any(ord(c) > 0x7F or ord(c) == 0 for c in s)
+    if has_high_chars and not re_dbl_quoted.match(s) and not re_html.match(s):
+        return True
+
+    for test_re in [re_all_numeric, re_dbl_quoted, re_html]:
+        if test_re.match(s):
+            return False
+
+    return None
+
+
+def id_needs_quotes(s):
     """Checks whether a string is a dot language ID.
 
     It will check whether the string is solely composed
@@ -319,19 +349,12 @@ def needs_quotes(s):
     if s in dot_keywords:
         return False
 
-    has_high_chars = any(ord(c) > 0x7F or ord(c) == 0 for c in s)
-    if (
-        has_high_chars
-        and not id_re_dbl_quoted.match(s)
-        and not id_re_html.match(s)
-    ):
-        return True
+    any_result = any_needs_quotes(s)
+    if any_result is not None:
+        return any_result
 
     for test_re in [
         id_re_alpha_nums,
-        id_re_num,
-        id_re_dbl_quoted,
-        id_re_html,
         id_re_alpha_nums_with_ports,
     ]:
         if test_re.match(s):
@@ -339,12 +362,12 @@ def needs_quotes(s):
 
     m = id_re_with_port.match(s)
     if m:
-        return needs_quotes(m.group(1)) or needs_quotes(m.group(2))
+        return id_needs_quotes(m.group(1)) or id_needs_quotes(m.group(2))
 
     return True
 
 
-def quote_if_necessary(s):
+def quote_id_if_necessary(s):
     """Enclose attribute value in quotes, if needed."""
     if isinstance(s, bool):
         if s is True:
@@ -357,18 +380,27 @@ def quote_if_necessary(s):
     if not s:
         return s
 
-    if needs_quotes(s):
-        replace = {
-            '"': r"\"",
-            "\n": r"\n",
-            "\r": r"\r",
-        }
-        for a, b in replace.items():
-            s = s.replace(a, b)
-
-        return '"' + s + '"'
+    if id_needs_quotes(s):
+        return make_quoted(s)
 
     return s
+
+
+def quote_attr_if_necessary(s):
+    if isinstance(s, bool):
+        return str(s)
+
+    if not isinstance(s, str):
+        return s
+
+    if s in dot_keywords:
+        return make_quoted(s)
+
+    any_result = any_needs_quotes(s)
+    if any_result is not None and not any_result:
+        return s
+
+    return make_quoted(s)
 
 
 def graph_from_dot_data(s):
@@ -664,7 +696,7 @@ class Node(Common):
             if isinstance(name, int):
                 name = str(name)
 
-            self.obj_dict["name"] = quote_if_necessary(name)
+            self.obj_dict["name"] = quote_id_if_necessary(name)
             self.obj_dict["port"] = port
 
     def __str__(self):
@@ -696,7 +728,7 @@ class Node(Common):
         """Return string representation of node in DOT language."""
         # RMF: special case defaults for node, edge and graph properties.
         #
-        node = quote_if_necessary(self.obj_dict["name"])
+        node = quote_id_if_necessary(self.obj_dict["name"])
 
         node_attr = []
 
@@ -705,7 +737,7 @@ class Node(Common):
             if value == "":
                 value = '""'
             if value is not None:
-                node_attr.append(f"{attr}={quote_if_necessary(value)}")
+                node_attr.append(f"{attr}={quote_attr_if_necessary(value)}")
             else:
                 node_attr.append(attr)
 
@@ -761,7 +793,7 @@ class Edge(Common):
             src = src.get_name()
         if isinstance(dst, (Node, Subgraph, Cluster)):
             dst = dst.get_name()
-        points = (quote_if_necessary(src), quote_if_necessary(dst))
+        points = (quote_id_if_necessary(src), quote_id_if_necessary(dst))
         self.obj_dict["points"] = points
         if obj_dict is None:
             # Copy the attributes
@@ -843,8 +875,8 @@ class Edge(Common):
             a = node_str[:node_port_idx]
             b = node_str[node_port_idx + 1 :]
 
-            node = quote_if_necessary(a)
-            node += ":" + quote_if_necessary(b)
+            node = quote_id_if_necessary(a)
+            node += ":" + quote_id_if_necessary(b)
 
             return node
 
@@ -881,7 +913,7 @@ class Edge(Common):
             if value == "":
                 value = '""'
             if value is not None:
-                edge_attr.append(f"{attr}={quote_if_necessary(value)}")
+                edge_attr.append(f"{attr}={quote_attr_if_necessary(value)}")
             else:
                 edge_attr.append(attr)
 
@@ -956,7 +988,7 @@ class Graph(Common):
                     "Accepted graph types are: graph, digraph"
                 )
 
-            self.obj_dict["name"] = quote_if_necessary(graph_name)
+            self.obj_dict["name"] = quote_id_if_necessary(graph_name)
             self.obj_dict["type"] = graph_type
 
             self.obj_dict["strict"] = strict
@@ -1408,7 +1440,7 @@ class Graph(Common):
                 if val == "":
                     val = '""'
                 if val is not None:
-                    graph.append(f"{attr}={quote_if_necessary(val)}")
+                    graph.append(f"{attr}={quote_attr_if_necessary(val)}")
                 else:
                     graph.append(attr)
 
@@ -1583,7 +1615,9 @@ class Cluster(Graph):
 
         if obj_dict is None:
             self.obj_dict["type"] = "subgraph"
-            self.obj_dict["name"] = quote_if_necessary("cluster_" + graph_name)
+            self.obj_dict["name"] = quote_id_if_necessary(
+                "cluster_" + graph_name
+            )
 
 
 __generate_attribute_methods(Cluster, CLUSTER_ATTRIBUTES)

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -367,18 +367,21 @@ def id_needs_quotes(s):
     return True
 
 
-def quote_id_if_necessary(s):
-    """Enclose attribute value in quotes, if needed."""
-    if isinstance(s, bool):
-        if s is True:
-            return "True"
-        return "False"
+def quote_id_if_necessary(s, unquoted_keywords=list()):
+    """Enclose identifier in quotes, if needed."""
+    unquoted = [w.lower() for w in unquoted_keywords]
 
+    if isinstance(s, bool):
+        return str(s).lower()
     if not isinstance(s, str):
         return s
-
     if not s:
         return s
+
+    if s.lower() in unquoted:
+        return s
+    if s.lower() in dot_keywords:
+        return make_quoted(s)
 
     if id_needs_quotes(s):
         return make_quoted(s)
@@ -752,7 +755,9 @@ class Node(Common):
         """Return string representation of node in DOT language."""
         # RMF: special case defaults for node, edge and graph properties.
         #
-        node = quote_id_if_necessary(self.obj_dict["name"])
+        node = quote_id_if_necessary(
+            self.obj_dict["name"], unquoted_keywords=("graph", "node", "edge")
+        )
 
         # No point in having default nodes that don't set any attributes...
         if (

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -319,6 +319,9 @@ def any_needs_quotes(s):
 
     Returns True, False, or None if the result is indeterminate.
     """
+    if s.isalnum():
+        return False
+
     has_high_chars = any(ord(c) > 0x7F or ord(c) == 0 for c in s)
     if has_high_chars and not re_dbl_quoted.match(s) and not re_html.match(s):
         return True
@@ -670,12 +673,14 @@ class Common:
             for k, v in self.obj_dict["attributes"].items()
         ]
 
-    def attrs_string(self):
-        """Format the current attributes list for output."""
+    def attrs_string(self, prefix=""):
+        """Format the current attributes list for output.
+
+        The `prefix` string will be prepended iff text is generated."""
         attrs = self.formatted_attr_list()
         if not attrs:
             return ""
-        return f"[{', '.join(attrs)}]"
+        return f"{prefix}[{', '.join(attrs)}]"
 
 
 class Node(Common):
@@ -766,7 +771,7 @@ class Node(Common):
         ):
             return ""
 
-        return f"{node} {self.attrs_string()};"
+        return f"{node}{self.attrs_string(prefix=" ")};"
 
 
 __generate_attribute_methods(Node, NODE_ATTRIBUTES)
@@ -920,9 +925,7 @@ class Edge(Common):
         else:
             edge.append(dst)
 
-        if self.attrs_string():
-            edge.append(self.attrs_string())
-        return " ".join(edge) + ";"
+        return f"{' '.join(edge)}{self.attrs_string(prefix=" ")};"
 
 
 __generate_attribute_methods(Edge, EDGE_ATTRIBUTES)

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -667,7 +667,7 @@ class Common:
         """Return a list of the class's attributes as formatted strings."""
         return [
             self._format_attr(k, v)
-            for k, v in sorted(self.obj_dict["attributes"].items())
+            for k, v in self.obj_dict["attributes"].items()
         ]
 
     def attrs_string(self):

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -723,7 +723,7 @@ class Node(Common):
             if isinstance(name, int):
                 name = str(name)
 
-            self.obj_dict["name"] = quote_id_if_necessary(name)
+            self.obj_dict["name"] = name
             self.obj_dict["port"] = port
 
     def __str__(self):
@@ -807,7 +807,7 @@ class Edge(Common):
             src = src.get_name()
         if isinstance(dst, (Node, Subgraph, Cluster)):
             dst = dst.get_name()
-        points = (quote_id_if_necessary(src), quote_id_if_necessary(dst))
+        points = (src, dst)
         self.obj_dict["points"] = points
         if obj_dict is None:
             # Copy the attributes
@@ -988,7 +988,7 @@ class Graph(Common):
                     "Accepted graph types are: graph, digraph"
                 )
 
-            self.obj_dict["name"] = quote_id_if_necessary(graph_name)
+            self.obj_dict["name"] = graph_name
             self.obj_dict["type"] = graph_type
 
             self.obj_dict["strict"] = strict
@@ -1430,7 +1430,7 @@ class Graph(Common):
             "show_keyword", True
         ):
             graph_type = ""
-        graph_name = self.obj_dict["name"]
+        graph_name = quote_id_if_necessary(self.obj_dict["name"])
         s = f"{graph_type} {graph_name} {{\n"
         graph.append(s)
 

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -370,9 +370,11 @@ def id_needs_quotes(s):
     return True
 
 
-def quote_id_if_necessary(s, unquoted_keywords=list()):
+def quote_id_if_necessary(s, unquoted_keywords=None):
     """Enclose identifier in quotes, if needed."""
-    unquoted = [w.lower() for w in unquoted_keywords]
+    unquoted = [
+        w.lower() for w in list(unquoted_keywords if unquoted_keywords else [])
+    ]
 
     if isinstance(s, bool):
         return str(s).lower()

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -771,7 +771,7 @@ class Node(Common):
         ):
             return ""
 
-        return f"{node}{self.attrs_string(prefix=" ")};"
+        return f"{node}{self.attrs_string(prefix=' ')};"
 
 
 __generate_attribute_methods(Node, NODE_ATTRIBUTES)
@@ -925,7 +925,7 @@ class Edge(Common):
         else:
             edge.append(dst)
 
-        return f"{' '.join(edge)}{self.attrs_string(prefix=" ")};"
+        return f"{' '.join(edge)}{self.attrs_string(prefix=' ')};"
 
 
 __generate_attribute_methods(Edge, EDGE_ATTRIBUTES)


### PR DESCRIPTION
As the scope of #339 has creeped rather a lot and threatened to push it into a state of perpetual limbo, I've started splitting out some of the changes into more focused PRs. This is another one of those, though the rather far-ranging nature might make it seem otherwise. This PR affects:

#### Attribute formatting
* Separate ID and attribute quoting, the same way #339 started out doing
* Fix quoting for attribute values
* Completely _rewrite_ the attribute **formatting** process, moving the meat of the work into new, centralized `Common` methods, which all classes' `to_string()` methods now call to get their formatted attributes
* Remove the attribute sorting, stomping on @lkk7's #361 (sorry! I did cherry-pick your test fixes into this PR, though.)

#### Name storage & formatting
* Remove all quoting of ID strings on _input_, switching to instead always performing quoting on _output_, so that strings are stored internally the same way the user inputs them, making lookups via `.get_*()` methods less confusing/annoying.
* Take advantage of the fact that we know when we're outputting a name vs. some other syntax, and quote graphviz keywords used as names to avoid syntax errors in the generated source. Make exception for the default-values node names.

Closes #361 
Closes #355
Closes #181
Fixes #358 
Fixes #282 
Fixes #258 
Fixes #246 
Fixes #180 
Fixes #111 
Fixes #85 
