### PR TITLE
Fix parenting behavior for duplicate-name nodes

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1102,11 +1102,13 @@ class Graph(Common):
             self.obj_dict["nodes"][graph_node.get_name()] = [
                 graph_node.obj_dict
             ]
-            graph_node.set_parent_graph(self.get_parent_graph())
         else:
             self.obj_dict["nodes"][graph_node.get_name()].append(
                 graph_node.obj_dict
             )
+
+        if not node or graph_node.get_parent_graph() is None:
+            graph_node.set_parent_graph(self.get_parent_graph())
 
         graph_node.set_sequence(self.get_next_sequence_number())
 

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -340,6 +340,28 @@ class TestGraphAPI(PydotTestCase):
         self.assertRaises(TypeError, self.graph_directed.add_subgraph, 1)
         self.assertRaises(TypeError, self.graph_directed.add_subgraph, "a")
 
+    def test_node_parenting(self):
+        g = pydot.Dot()
+        n = pydot.Node("node a")
+        n2 = pydot.Node("node a")
+        g.add_node(n)
+        g.add_node(n2)
+
+        nodes = g.get_node('"node a"')
+        for node in nodes:
+            assert node.get_parent_graph() == g
+
+        sg = pydot.Subgraph("sub sg")
+        sg_n = pydot.Node("node a")
+        sg.add_node(sg_n)
+        self.assertEqual(sg_n.get_parent_graph(), sg)
+
+        g.add_node(sg_n)
+        self.assertEqual(sg_n.get_parent_graph(), sg)
+
+        g.add_subgraph(sg)
+        self.assertEqual(sg_n.get_parent_graph(), g)
+
     def test_quoting(self):
         g = pydot.Dot()
         g.add_node(pydot.Node("test", label=string.printable))


### PR DESCRIPTION
While working on writing tests for #363, I discovered an oddity in the parenting behavior of `add_node()`. The code previously would only call `set_parent_graph()` on the _first_ node added with a given name — if additional nodes were subsequently added with the same name, their parent graph wouldn't be set.

I considered that there might be an intent behind this. (Perhaps the assumption is that the node is the _same_ node, and therefore already has the current graph as its parent. Or, perhaps the thinking is that the node may already be a member of a different (sub-)graph, and therefore already have a parent.)

Regardless, we should _check_ whether that's the case, and at least if the node **doesn't** have a parent already, always set it to the current graph. So, the code now does that, to prevent situations like this:

```python
>>> # (With the code prior to this PR...)
>>> import pydot
>>> g = pydot.Graph()
>>> a = pydot.Node("my node")
>>> b = pydot.Node("my node")
>>> g.add_node(a)
>>> g.add_node(b)
>>> a.get_parent_graph() == g
True
>>> b.get_parent_graph() is None
True
```

If the node already has a parent, it's left alone:

```python
>>> # (In the PR code...)
>>> import pydot
>>> g = pydot.Graph()
>>> a = pydot.Node("my node")
>>> b = pydot.Node("my node")
>>> g.add_node(a)
>>> g.add_node(b)
>>> a.get_parent_graph() == g
True
>>> b.get_parent_graph() == g
True
>>> sg = pydot.Subgraph("sg")
>>> c = pydot.Node("my node")
>>> sg.add_node(c)
>>> g.add_node(c)
>>> c.get_parent_graph() == sg
True
>>> # Adding the subgraph to the Graph still reparents all children
>>> g.add_subgraph(sg)
>>> c.get_parent_graph() == g
True
```

A new `test_node_parenting()` does basically those steps, and confirms the proper parenting behavior.
