### PR TITLE
authors += @ferdnyc, @lkk7; maintainers += @lkk7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,9 +14,12 @@ dependencies = [
 authors = [
   {name = "Ero Carrera", email = "ero.carrera@gmail.com"},
   {name = "Peter Nowee", email = "peter@peternowee.com"},
+  {name = "Łukasz", email = "lukaszlapinski7@gmail.com"},
+  {name = "FeRD (Frank Dana)", email = "ferdnyc@gmail.com"},
 ]
 maintainers = [
   {name = "Peter Nowee", email = "peter@peternowee.com"},
+  {name = "Łukasz", email = "lukaszlapinski7@gmail.com"},
 ]
 keywords = ["graphviz", "dot", "graphs", "visualization"]
 classifiers = [


### PR DESCRIPTION
The package metadata just seemed objectively out of sync with recent reality. Figure it's past time we {claim some credit | accept our share of blame} for this nonsense.

@lkk7: I just copied<sup>1</sup> the name and email fields from your commits verbatim, feel free to self-apply suggestions to adjust them however you prefer.

And feel free to reject outright, if you're in any way hesitant about any part of this change.


<sup>1</sup>: (Technically I _retyped_ your email address, actually, so please double-check my spelling.)