### PR TITLE
Parser: tighten port syntax

### DIFF
--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -407,7 +407,10 @@ def graph_definition():
 
         righthand_id = (float_number | ID).setName("righthand_id")
 
-        port = Group(OneOrMore(Group(colon + ID))).setName("port")
+        port = (
+            Group(Group(colon + ID) + Group(colon + ID))
+            | Group(Group(colon + ID))
+        ).setName("port")
 
         node_id = ID + Optional(port)
         a_list = OneOrMore(


### PR DESCRIPTION
Only accept strings of the form ':id' or ':id:id' as ports.