### PR TITLE
Fix edge quoting (broken in 3.0.0)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,10 @@ Pydot versions since 1.4.2 adhere to [PEP 440-style semantic versioning]
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+This is a bugfix release to correct a critical error introduced in 3.0.0.
+
+Changed:
+- Fix quoting in `Edge.to_string()`. (#384)
 
 
 3.0.0 (2024-07-15)

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -903,7 +903,7 @@ class Edge(Common):
 
             return node
 
-        return node_str
+        return quote_id_if_necessary(node_str)
 
     def to_string(self):
         """Return string representation of edge in DOT language."""

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -397,6 +397,23 @@ class TestGraphAPI(PydotTestCase):
                 """),
         )
 
+    def test_edge_quoting(self):
+        """Test the fix for issue #383 (pydot 3.0.0)."""
+        g = pydot.Graph("", graph_type="digraph")
+        g.add_node(pydot.Node("Node^A"))
+        g.add_node(pydot.Node("Node^B"))
+        g.add_edge(pydot.Edge("Node^A", "Node^B"))
+        self.assertEqual(
+            g.to_string(),
+            textwrap.dedent("""\
+            digraph  {
+            "Node^A";
+            "Node^B";
+            "Node^A" -> "Node^B";
+            }
+            """),
+        )
+
     def test_id_storage_and_lookup(self):
         g = pydot.Graph()
         a = pydot.Node("my node")


### PR DESCRIPTION
I missed a crucial call to `quote_id_if_necessary()` in the `to_string()` path for `pydot.Edge`, so it's broken in 3.0.0 and leaves some values unquoted that need to be quoted.

This PR adds a fix and a test. I'd suggest an immediate bugfix release of 3.0.1.

Fixes #383 
