### PR TITLE
Ensure license files end up in wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = 'pydot'
 description = "Python interface to Graphviz's Dot"
 readme = "README.md"
-license = {file = "LICENSE"}
+license = {text = "MIT"}
 requires-python = ">= 3.8"
 dependencies = [
   'pyparsing>=3.0.9'
@@ -48,6 +48,11 @@ dynamic = [
 
 [tool.setuptools.dynamic]
 version = {attr = "pydot.__version__"}
+
+[tool.setuptools]
+license-files = [
+   'LICENSES/*',
+]
 
 [project.urls]
 Homepage = "https://github.com/pydot/pydot"


### PR DESCRIPTION
Add a `[tool.setuptools]` section to `pyproject.toml` containing a `license-files` array that globs for all of our license files, to ensure they end up in the built wheel.

The files end up at the root of the `.dist-info` directory, not in a `LICENSES` subdirectory, but I don't know how to change that and it seems "fine". At least they're there.

Fixes #390 