### PR TITLE
Use temporary directories for temporary file output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,6 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
-test.svg
 
 # Translations
 *.mo

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1776,44 +1776,34 @@ class Dot(Graph):
             args = []
 
         # temp file
-        tmp_fd, tmp_name = tempfile.mkstemp()
-        os.close(tmp_fd)
-        self.write(tmp_name, encoding=encoding)
-        tmp_dir = os.path.dirname(tmp_name)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            fp = tempfile.NamedTemporaryFile(dir=tmp_dir, delete=False)
+            fp.close()
+            self.write(fp.name, encoding=encoding)
 
-        # For each of the image files...
-        for img in self.shape_files:
-            # Get its data
-            f = open(img, "rb")
-            f_data = f.read()
-            f.close()
-            # And copy it under a file with the same name in
-            # the temporary directory
-            f = open(os.path.join(tmp_dir, os.path.basename(img)), "wb")
-            f.write(f_data)
-            f.close()
+            # For each of the image files, copy it to the temporary directory
+            # with the same filename as the original
+            for img in self.shape_files:
+                outfile = os.path.join(tmp_dir, os.path.basename(img))
+                with open(img, "rb") as img_in, open(outfile, "wb") as img_out:
+                    img_data = img_in.read()
+                    img_out.write(img_data)
 
-        arguments = [f"-T{format}"] + args + [tmp_name]
+            arguments = [f"-T{format}"] + args + [fp.name]
 
-        try:
-            stdout_data, stderr_data, process = call_graphviz(
-                program=prog,
-                arguments=arguments,
-                working_dir=tmp_dir,
-            )
-        except OSError as e:
-            if e.errno == errno.ENOENT:
-                args = list(e.args)
-                args[1] = f'"{prog}" not found in path.'
-                raise OSError(*args)
-            else:
-                raise
-
-        # clean file litter
-        for img in self.shape_files:
-            os.unlink(os.path.join(tmp_dir, os.path.basename(img)))
-
-        os.unlink(tmp_name)
+            try:
+                stdout_data, stderr_data, process = call_graphviz(
+                    program=prog,
+                    arguments=arguments,
+                    working_dir=tmp_dir,
+                )
+            except OSError as e:
+                if e.errno == errno.ENOENT:
+                    args = list(e.args)
+                    args[1] = f'"{prog}" not found in path.'
+                    raise OSError(*args)
+                else:
+                    raise
 
         if process.returncode != 0:
             code = process.returncode

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -16,6 +16,7 @@ import os
 import pickle
 import string
 import sys
+import tempfile
 import textwrap
 import unittest
 from hashlib import sha256
@@ -462,7 +463,9 @@ class TestGraphAPI(PydotTestCase):
         g = pydot.Dot()
         u = pydot.Node("a")
         g.add_node(u)
-        g.write_svg("test.svg", prog=["twopi", "-Goverlap=scale"])
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            outfile = os.path.join(tmp_dir, "test.svg")
+            g.write_svg(outfile, prog=["twopi", "-Goverlap=scale"])
 
     def test_edge_equality_basics_3_same_points_not_not_equal(self):
         # Fail example: pydot 1.4.1 on Python 2.


### PR DESCRIPTION
This PR modernizes the handling of temporary files, switching to the `tempfile.TemporaryDirectory()` context manager in both `pydot.core.Dot.write()`, and the `test_dot_args()` unit test (which previously created a `test.svg` file in whatever directory the tests were run from).

Using the context manager means that temporary files will be cleaned up in _all_ cases, even when exceptions are raised or things exit unexpectedly. I have a _lot_ of `/tmp/tmpXXXXXX` files containing graphviz code on my system, to prove that this wasn't happening reliably before.

There is some danger using `tempfile.TemporaryDirectory()` on Windows systems, which can encounter permissions errors during cleanup. An `ignore_cleanup_errors` argument was introduced in Python 3.10 to handle those, but isn't available in older releases. We'll have to see how the Windows CI runs turn out.