### PR TITLE
Tests: Add coverage, use pytest as test runner

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -10,7 +10,9 @@ source =
 [run]
 branch = true
 parallel = true
+relative_files = true
 source =
-  pydot
   test
+source_pkgs =
+  pydot
 

--- a/.coveragerc
+++ b/.coveragerc
@@ -5,6 +5,7 @@
 [paths]
 source =
   src
+  */site-packages
 
 [run]
 branch = true

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,11 @@
+[paths]
+source =
+  src
+
+[run]
+branch = true
+parallel = true
+source =
+  pydot
+  test
+

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
 [paths]
 source =
   src

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
 # Flag PRs touching the coverage workflows for additional scrutiny
 /.github/workflows/CI.yml: @lkk7
 /.github/workflows/coverage.yml: @lkk7

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Flag PRs touching the coverage workflows for additional scrutiny
+/.github/workflows/CI.yml: @lkk7
+/.github/workflows/coverage.yml: @lkk7
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 # Flag PRs touching the coverage workflows for additional scrutiny
-/.github/workflows/CI.yml: @lkk7
-/.github/workflows/coverage.yml: @lkk7
+/.github/workflows/CI.yml       @lkk7
+/.github/workflows/coverage.yml @lkk7
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,6 +99,22 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     needs: tests
+    permissions:
+      # NOTE: These permissions will only really be relevant for
+      # internal PRs (those based on a branch in the repo). When
+      # running in a PR branch from a fork, GitHub's standard
+      # permissions won't allow writing to the repo, which is why
+      # coverage data is published as a build artifact and passed
+      # to the secure workflow in coverage.yml for processing.
+      # See: py-cov-action/python-coverage-comment-action#461
+      #
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for pushing data to the
+      # python-coverage-comment-action branch, and for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
     steps:
       - name: "Check out source"
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           python-version: "${{ matrix.python-version }}"
           cache: "pip"
-      - name: "Set up TEST_ERROR_DIR"
+      - name: "Set up environment"
         shell: bash
         run: |
           mkdir test_errors
@@ -62,6 +62,7 @@ jobs:
           else
             echo "TEST_ERROR_DIR=$(pwd -P)/test_errors" >> "$GITHUB_ENV"
           fi
+          echo "COVERAGE_FILE=.coverage.${{ runner.os }}.${{ matrix.python-version }}" >> "$GITHUB_ENV"
       - name: "Install graphviz (Linux)"
         if: runner.os == 'linux'
         run: sudo apt install graphviz
@@ -99,6 +100,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: tests
     steps:
+      - name: "Check out source"
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          fetch-depth: 0
       - name: "Install coverage.py"
         run: python -m pip install coverage
       - name: "Download coverage-data artifacts"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,3 +87,27 @@ jobs:
           name: test-errors-${{ runner.os }}-${{ matrix.python-version }}
           path: ${{ env.TEST_ERROR_DIR }}
           if-no-files-found: ignore
+      - name: "Publish coverage-data artifact"
+        if: ${{ always() }}
+        uses: actions/upload-artifact@0b2256b8c012f0828dc542b3febcab082c67f72b # v4.3.4
+        with:
+          name: coverage-data-${{ runner.os }}-${{ matrix.python-version }}
+          path: .coverage.*
+          if-no-files-found: ignore
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: tests
+    steps:
+      - name: "Install coverage.py"
+        run: python -m pip install coverage
+      - name: "Download coverage-data artifacts"
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-data-*
+          merge-multiple: true
+      - name: "Combine coverage data"
+        run: coverage combine
+      - name: "Report aggregate coverage"
+        run: coverage report
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,8 +111,20 @@ jobs:
         with:
           pattern: coverage-data-*
           merge-multiple: true
-      - name: "Combine coverage data"
-        run: coverage combine
-      - name: "Report aggregate coverage"
-        run: coverage report
-
+      # - name: "Combine coverage data"
+      #   run: coverage combine
+      # - name: "Report aggregate coverage"
+      #   run: coverage report
+      - name: "Coverage comment"
+        id: coverage_comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}
+          MERGE_COVERAGE_FILES: true
+          ANNOTATE_MISSING_LINES: true
+      - name: "Store PR comment for secure workflow"
+        uses: actions/upload-artifact@v4
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        with:
+          name: python-coverage-comment-action
+          path: python-coverage-comment-action.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,35 @@
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+jobs:
+  test:
+    name: Display coverage results
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      # Gives the action the necessary permissions for publishing new
+      # comments in pull requests.
+      pull-requests: write
+      # Gives the action the necessary permissions for editing existing
+      # comments (to avoid publishing multiple comments in the same PR)
+      contents: write
+      # Gives the action the necessary permissions for looking up the
+      # workflow that launched this workflow, and download the related
+      # artifact that contains the comment to be published
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          # Update those if you changed the default values:
+          # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          # COMMENT_FILENAME: python-coverage-comment-action.txt

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2024 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
 name: Post coverage comment
 
 on:
@@ -33,3 +37,4 @@ jobs:
           # Update those if you changed the default values:
           # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
           # COMMENT_FILENAME: python-coverage-comment-action.txt
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,9 @@ tests = [
   'parameterized',
   'ruff',
   'tox',
-  'unittest-parallel',
+  'pytest',
+  'pytest-cov',
+  'pytest-xdist[psutil]',
 ]
 release = ['zest.releaser[recommended]']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ pass_env =
 commands = unittest-parallel --level test -vv
 
 [testenv:ruff]
+skip_install = true
 deps = ruff==0.4.8
 commands = 
     ruff format --diff .

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,9 @@ push-changes=no
 create-wheel=yes
 tag-format=v{version}
 
+[tool:pytest]
+testpaths = test
+
 [tox:tox]
 min_version = 4.6.3
 env_list =
@@ -25,7 +28,9 @@ package = wheel
 wheel_build_env = .pkg
 pass_env =
     TEST_ERROR_DIR
-commands = unittest-parallel --level test -vv
+setenv = 
+    COVERAGE_FILE = .coverage.{envname}
+commands = pytest -n auto --cov
 
 [testenv:ruff]
 skip_install = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,8 @@ wheel_build_env = .pkg
 pass_env =
     TEST_ERROR_DIR
 setenv = 
-    COVERAGE_FILE = .coverage.{envname}
+    DEFAULT_COVERAGE_FILE = .coverage.{envname}
+    COVERAGE_FILE = {env:COVERAGE_FILE:{env:DEFAULT_COVERAGE_FILE}}
 commands = pytest -n auto --cov
 
 [testenv:ruff]


### PR DESCRIPTION
As promised, this is a WIP set of changes to add code coverage collection and reporting to our CI testing, switching from unittest-parallel to pytest (with pytest-xdist and pytest-cov plugins) as the test runner.

As it turns out, happily we **don't** have to convert the base test code away from unittest in order to reap the benefits of pytest's parallelism and code-coverage integrations. I still think we SHOULD, but for the moment testing with pytest running the unittest-based tests seems to work fine.

The PR currently contains the necessary `setup.cfg` changes to integrate pytest and coverage-collection, along with a `.coveragerc` to configure the process and GitHub Actions workflow changes to collect and aggregate the coverage data.

It's that last step that fails, because the coverage data from the various runners appears to embed full paths to the module being tested. In the separate coverage job (which runs after all of the testing, always on Ubuntu using the system python) those installed paths no longer exist. (And can't be recreated because they embed paths specific to the tox environment in use at the time.) So `coverage report` immediately bails with an error like this:

> No source for code: '/Users/runner/work/pydot/pydot/.tox/py310/lib/python3.10/site-packages/pydot/__init__.py'.
> Error: Process completed with exit code 1.

So, the first step is figuring out how that's all supposed to be made to work, I assume it's just a `.coveragerc` setting that needs to be tweaked, or something.

Then we need to figure out how to get the coverage data _reported_ usefully. (`coverage report` just produces a summary like this, which isn't immediately helpful for evaluating PR changes and the like:)
```text
Name                                                          Stmts   Miss Branch BrPart  Cover
  -----------------------------------------------------------------------------------------------
  .tox/py312/lib/python3.12/site-packages/pydot/__init__.py         9      0      0      0   100%
  .tox/py312/lib/python3.12/site-packages/pydot/core.py           687    124    298     34    79%
  .tox/py312/lib/python3.12/site-packages/pydot/dot_parser.py     273     44    134     23    80%
  .tox/py312/lib/python3.12/site-packages/pydot/exceptions.py       6      2      0      0    67%
  test/__init__.py                                                  0      0      0      0   100%
  test/test_pydot.py                                              386     28     52      8    90%
  -----------------------------------------------------------------------------------------------
  TOTAL                                                          1361    198    484     65    82%
```

(Our overall coverage numbers are actually better than I'd expected, which is good news.)

And we need to decide about converting the test suite itself from unittest to pytest, which I still think is a good idea and worth doing, but appears to be less urgent than it initially appeared.

### TODO

- [ ] Fix paths in coverage data so that `coverage combine` isn't looking for runner-specific paths
- [ ] Set up some sort of coverage annotation/reporting driven by the collected data
- [ ] Migrate tests from unittest to pytest?

### Effects on CI runs

Not particularly surprisingly, adding coverage collection has almost no effect on the Ubuntu or macOS runners. (In fact, the execution time difference falls within the general randomness of job execution times for GitHub Actions overall — could be a bit slower, could be a bit faster.) On Windows, it adds maybe 40-60 seconds (40%) to the execution time for each runner. So, not unreasonably slow by any means.

(A recent run on `main`, vs. a run on this branch)

![image](https://github.com/user-attachments/assets/d12c3571-ebfa-4b7e-89ff-8571baf31b1d) ![image](https://github.com/user-attachments/assets/cc739e8f-ea28-4489-bc6c-6bd327f830a2)
