### PR TITLE
Eliminate parser's top_graphs global

### DIFF
--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -74,11 +74,9 @@ class DefaultStatement(P_AttrList):
         return f"{name}({self.default_type}, {self.attrs!r})"
 
 
-top_graphs = []
-
-
 def push_top_graph_stmt(s, loc, toks):
     attrs = {}
+    top_graphs = []
     g = None
 
     for element in toks:
@@ -502,8 +500,6 @@ def parse_dot_data(s):
     @return: Graphs that result from parsing.
     @rtype: `list` of `pydot.Dot`
     """
-    global top_graphs
-    top_graphs = []
     try:
         graphparser = graph_definition()
         graphparser.parseWithTabs()


### PR DESCRIPTION
Turns out it isn't needed, as the list can simply be created locally in `push_top_graph_stmt` and returned from there.

Note that this WON'T make the parser thread-safe, as pyparsing itself isn't thread-safe. But it'll remove a data race in our parser module, when handling the output of the parser.

See #401