### PR TITLE
Drop parent_edge_list/parent_node_list

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -707,7 +707,6 @@ class Node(Common):
             self.obj_dict["attributes"] = dict(attrs)
             self.obj_dict["type"] = "node"
             self.obj_dict["parent_graph"] = None
-            self.obj_dict["parent_node_list"] = None
             self.obj_dict["sequence"] = None
 
             # Remove the compass point
@@ -812,7 +811,6 @@ class Edge(Common):
             self.obj_dict["attributes"] = dict(attrs)
             self.obj_dict["type"] = "edge"
             self.obj_dict["parent_graph"] = None
-            self.obj_dict["parent_edge_list"] = None
             self.obj_dict["sequence"] = None
         else:
             self.obj_dict = obj_dict


### PR DESCRIPTION
They are never referenced again, after being created empty during object initialization.

I think this technically fixes #295, though that's already closed because the original reporter mistook `parent_graph` (which IS used, frequently) for the _actual_ unused keys. But they were correct, in pointing out that there are completely unused entries in our `obj_dict`s.