### PR TITLE
Add posargs to tox commands

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,13 +25,13 @@ package = wheel
 wheel_build_env = .pkg
 pass_env =
     TEST_ERROR_DIR
-commands = unittest-parallel --level test -vv
+commands = unittest-parallel --level test -vv {posargs}
 
 [testenv:ruff]
 deps = ruff==0.4.8
 commands = 
     ruff format --diff .
-    ruff check .
+    ruff check . {posargs}
 
 # For tox-gh
 [gh]


### PR DESCRIPTION
Allows running commands with extra args, e.g.

```bash
echo "Run unit tests with fail-fast option to abort on first error"
tox -e py312 -- -f

echo "Have ruff auto-apply fixes for issues it finds in check mode"
tox -e ruff -- --fix
```