### PR TITLE
Fix quoting of leading-numeral strings, and add tests

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -309,8 +309,14 @@ def any_needs_quotes(s):
 
     Returns True, False, or None if the result is indeterminate.
     """
-    if s.isalnum():
+
+    # Strings consisting _only_ of digits are safe unquoted
+    if s.isdigit():
         return False
+
+    # MIXED-aphanumeric values need quoting if they *start* with a digit
+    if s.isalnum():
+        return s[0].isdigit()
 
     has_high_chars = any(ord(c) > 0x7F or ord(c) == 0 for c in s)
     if has_high_chars and not re_dbl_quoted.match(s) and not re_html.match(s):

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -408,6 +408,27 @@ class TestGraphAPI(PydotTestCase):
                 """),
         )
 
+    def test_alphanum_quoting(self):
+        """Test the fix for issue #408."""
+        g = pydot.Dot(graph_name="issue408", graph_type="graph")
+        n1 = pydot.Node(
+            "11herbs", label="and 11¼ spices", fontsize=12, height="1")
+        n2 = pydot.Node("nooks9nooks", fontsize="14pt", height="2in")
+        g.add_node(n1)
+        g.add_node(n2)
+        g.add_edge(pydot.Edge(n1, n2, minlength="4pt"))
+
+        self.assertEqual(
+            g.to_string(),
+            textwrap.dedent("""\
+                graph issue408 {
+                "11herbs" [label="and 11¼ spices", fontsize=12, height=1];
+                nooks9nooks [fontsize="14pt", height="2in"];
+                "11herbs" -- nooks9nooks [minlength="4pt"];
+                }
+                """),
+        )
+
     def test_edge_quoting(self):
         """Test the fix for issue #383 (pydot 3.0.0)."""
         g = pydot.Graph("", graph_type="digraph")

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -412,7 +412,8 @@ class TestGraphAPI(PydotTestCase):
         """Test the fix for issue #408."""
         g = pydot.Dot(graph_name="issue408", graph_type="graph")
         n1 = pydot.Node(
-            "11herbs", label="and 11¼ spices", fontsize=12, height="1")
+            "11herbs", label="and 11¼ spices", fontsize=12, height="1"
+        )
         n2 = pydot.Node("nooks9nooks", fontsize="14pt", height="2in")
         g.add_node(n1)
         g.add_node(n2)


### PR DESCRIPTION
`str.isalphanum` is _almost_ sufficient to decide that a string doesn't
need to be quoted — except, it DOES if it **starts** with a digit.

Unquoted `label=node1` is fine. `height=27` is fine. `fontsize=14pt` is _not_ fine, without being quoted.

Correct the logic in `pydot.core.any_needs_quotes` to account for this.

Fixes #408