### PR TITLE
Experimentally create separate ruff-check/fix envs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ env_list =
     py310
     py39
     py38
-    ruff
+    ruff-check
 
 [testenv]
 extras = tests
@@ -27,16 +27,22 @@ pass_env =
     TEST_ERROR_DIR
 commands = unittest-parallel --level test -vv {posargs}
 
-[testenv:ruff]
+[testenv:ruff-check]
 deps = ruff==0.4.8
 commands = 
     ruff format --diff .
     ruff check . {posargs}
 
+[testenv:ruff-fix]
+deps = ruff==0.4.8
+commands =
+    ruff format .
+    ruff check --fix .
+
 # For tox-gh
 [gh]
 python =
-    3.12 = py312, ruff
+    3.12 = py312, ruff-check
     3.11 = py311
     3.10 = py310
     3.9 = py39

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,7 @@ commands =
 # For tox-gh
 [gh]
 python =
-    3.12 = py312, ruff-check
+    3.12 = ruff-check, py312
     3.11 = py311
     3.10 = py310
     3.9 = py39


### PR DESCRIPTION
Since tox's `{posargs}` can't be used to transform a `ruff format --diff` call into a `ruff format` call, split the `ruff` env into a `ruff-check` env for the CI system, and a (non-default) `ruff-fix` env that can be run manually using `tox -e ruff-fix` to have changes auto-applied.

I _think_ this will work out with the CI setup (and `ruff-fix` will just be ignored because it isn't on any list of default environments, so it should be manual-only), but it'll be good to see how the first run goes.