### PR TITLE
Exclude _vendor from coverage and display badge in README

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -15,4 +15,9 @@ source =
   test
 source_pkgs =
   pydot
+omit =
+  **/_vendor/*
 
+[report]
+omit =
+  **/_vendor/*

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: MIT
 -->
 
 ![CI](https://github.com/pydot/pydot/actions/workflows/CI.yml/badge.svg)
+[![Coverage](https://raw.githubusercontent.com/pydot/pydot/python-coverage-comment-action-data/badge.svg)](https://htmlpreview.github.io/?https://github.com/pydot/pydot/blob/python-coverage-comment-action-data/htmlcov/index.html)
 [![PyPI](https://img.shields.io/pypi/v/pydot.svg)](https://pypi.org/project/pydot/)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-purple.svg)](https://github.com/astral-sh/ruff)
 


### PR DESCRIPTION
Get the uninteresting `_vendor/` code out of the coverage data, since it's not our job to test Python standard library classes.

Have the README display the coverage badge from the `python-coverage-comment-action-data` branch. (It's autogenerated from the action runs on `main` commits — so, currently 77%, but it'll be 86% after this merges — and stored at `/badge.svg` on the branch.) 