### PR TITLE
Remove deprecated parts of test_pydot.py

### DIFF
--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -667,23 +667,3 @@ class TestGraphvizRegressions(RenderedTestCase):
     def test_regression(self, _, fname, path):
         self._render_and_compare_dot_file(path, fname)
 
-
-def parse_args():
-    """Parse arguments. Deprecated since pydot 2.0."""
-    parser = argparse.ArgumentParser(add_help=False)
-    parser.add_argument("--no-check", action="store_true")
-    args, unknown = parser.parse_known_args()
-    if args.no_check:
-        print(
-            "WARNING: The --no-check option became redundant with pydot 2.0 "
-            "and will be removed in a future major release of pydot.\n",
-            file=sys.stderr,
-        )
-    # avoid confusing `unittest`
-    sys.argv = [sys.argv[0]] + unknown
-
-
-if __name__ == "__main__":
-    parse_args()
-    print(f"The tests are using `pydot` from:  {pydot}")
-    unittest.main(verbosity=2)

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -9,7 +9,6 @@
 # -test del_node, del_edge methods
 # -test Common.set method
 
-import argparse
 import functools
 import importlib
 import os
@@ -666,4 +665,3 @@ class TestGraphvizRegressions(RenderedTestCase):
     @parameterized.expand(functools.partial(_load_test_cases, TESTS_DIR_2))
     def test_regression(self, _, fname, path):
         self._render_and_compare_dot_file(path, fname)
-


### PR DESCRIPTION
`parse_args` has been documented as deprecated since Pydot 2.0, and the `if __name__ == "__main__"` block has been dead code since we removed the shebang line and switched to running the tests via tox. Drop both of them to boost coverage and reduce tech debt.