### PR TITLE
Remove periods from unquoted alphanumeric IDs

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -297,9 +297,9 @@ re_all_numeric = re.compile(r"^[0-9\.]+$")
 re_dbl_quoted = re.compile(r'^".*"$', re.S)
 re_html = re.compile(r"^<.*>$", re.S)
 
-id_re_alpha_nums = re.compile(r"^[_a-zA-Z][a-zA-Z0-9_\.]*$")
+id_re_alpha_nums = re.compile(r"^[_a-zA-Z][a-zA-Z0-9_]*$")
 id_re_alpha_nums_with_ports = re.compile(
-    r'^[_a-zA-Z][a-zA-Z0-9_\.:"]*[a-zA-Z0-9_\."]+$'
+    r'^[_a-zA-Z][a-zA-Z0-9_:"]*[a-zA-Z0-9_"]+$'
 )
 id_re_with_port = re.compile(r"^([^:]*):([^:]*)$")
 

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -429,6 +429,26 @@ class TestGraphAPI(PydotTestCase):
                 """),
         )
 
+    def test_alphanum_quoting2(self):
+        """Test the fix for issue #418."""
+        g = pydot.Dot(graph_name="issue418", graph_type="graph")
+        n1 = pydot.Node("foo.bar", color="red")
+        n2 = pydot.Node("baz", color="blue")
+        g.add_node(n1)
+        g.add_node(n2)
+        g.add_edge(pydot.Edge(n1, n2))
+
+        self.assertEqual(
+            g.to_string(),
+            textwrap.dedent("""\
+                graph issue418 {
+                "foo.bar" [color=red];
+                baz [color=blue];
+                "foo.bar" -- baz;
+                }
+                """),
+        )
+
     def test_edge_quoting(self):
         """Test the fix for issue #383 (pydot 3.0.0)."""
         g = pydot.Graph("", graph_type="digraph")


### PR DESCRIPTION
Turns out, while periods are valid in ALL-numeric IDs, they're NOT valid in unquoted alphanumeric IDs — a string like "foo.bar" needs to be quoted to parse properly. Fix the ID regular expressions to disallow periods in alphanumeric IDs, and add a unit test to verify that they're properly quoted.

Fixes #418