### PR TITLE
Move/rename pydot.core.frozendict to pydot.classes.FrozenDict, clean up, bugfix, and fully test

### DIFF
--- a/src/pydot/__init__.py
+++ b/src/pydot/__init__.py
@@ -16,5 +16,6 @@ _logger.debug("pydot initializing")
 _logger.debug("pydot %s", __version__)
 
 
+from pydot.classes import FrozenDict  # noqa: F401, E402
 from pydot.core import *  # noqa: F403, E402
 from pydot.exceptions import *  # noqa: E402, F403

--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -57,7 +57,7 @@ class FrozenDict(dict):
     def __new__(cls, *args, **kw):
         new = dict.__new__(cls)
         args_ = [cls._freeze_arg(arg) for arg in args]
-        dict.__init__(new, *args_, **kw)
+        dict.__init__(new, *args_, **cls._freeze_arg(kw))
         return new
 
     def __init__(self, *args, **kw):

--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -63,6 +63,14 @@ class FrozenDict(dict):
     def __init__(self, *args, **kw):
         pass
 
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return hash(self) == hash(other)
+        return NotImplemented
+
+    def __ne__(self, other):
+        return not self == other
+
     def __hash__(self):
         try:
             return self._cached_hash

--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2024 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Frozen dictionaries."""
+
+import copy
+
+
+class FrozenDict(dict):
+    """Frozen dictionary, values are immutable after creation.
+
+    Extended version of ASPN's Python Cookbook Recipe:
+    https://code.activestate.com/recipes/414283/
+
+    This version freezes dictionaries used as values within dictionaries."""
+
+    _block_msg = "A frozendict cannot be modified."
+
+    def __delitem__(self, key):
+        raise AttributeError(self._block_msg)
+
+    def __setitem__(self, key, value):
+        raise AttributeError(self._block_msg)
+
+    def clear(self):
+        raise AttributeError(self._block_msg)
+
+    def pop(self, key, default=None):
+        raise AttributeError(self._block_msg)
+
+    def popitem(self):
+        raise AttributeError(self._block_msg)
+
+    def setdefault(self, key, default=None):
+        raise AttributeError(self._block_msg)
+
+    def update(self, *E, **F):
+        raise AttributeError(self._block_msg)
+
+    @staticmethod
+    def _freeze_arg(in_arg):
+        if not isinstance(in_arg, dict):
+            return in_arg
+        arg = copy.copy(in_arg)
+        for k, v in arg.items():
+            if isinstance(v, FrozenDict):
+                continue
+            elif isinstance(v, dict):
+                arg[k] = FrozenDict(v)
+            elif isinstance(v, list):
+                arg[k] = tuple(
+                    FrozenDict(e) if isinstance(e, dict) else e for e in v
+                )
+        return arg
+
+    def __new__(cls, *args, **kw):
+        new = dict.__new__(cls)
+        args_ = [cls._freeze_arg(arg) for arg in args]
+        dict.__init__(new, *args_, **kw)
+        return new
+
+    def __init__(self, *args, **kw):
+        pass
+
+    def __hash__(self):
+        try:
+            return self._cached_hash
+        except AttributeError:
+            self._cached_hash = hash(tuple(self.items()))
+            return self._cached_hash
+
+    def __repr__(self):
+        dict_repr = dict.__repr__(self)
+        return f"FrozenDict({dict_repr})"

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -15,6 +15,7 @@ import sys
 import pydot
 import pydot.dot_parser
 from pydot._vendor import tempfile
+from pydot.classes import FrozenDict
 
 _logger = logging.getLogger(__name__)
 _logger.debug("pydot core module initializing")
@@ -220,65 +221,6 @@ def call_graphviz(program, arguments, working_dir, **kwargs):
     stdout_data, stderr_data = process.communicate()
 
     return stdout_data, stderr_data, process
-
-
-#
-# Extended version of ASPN's Python Cookbook Recipe:
-# Frozen dictionaries.
-# https://code.activestate.com/recipes/414283/
-#
-# This version freezes dictionaries used as values within dictionaries.
-#
-class frozendict(dict):
-    def _blocked_attribute(obj):
-        raise AttributeError("A frozendict cannot be modified.")
-
-    _blocked_attribute = property(_blocked_attribute)
-
-    __delitem__ = __setitem__ = clear = _blocked_attribute
-    pop = popitem = setdefault = update = _blocked_attribute
-
-    def __new__(cls, *args, **kw):
-        new = dict.__new__(cls)
-
-        args_ = []
-        for arg in args:
-            if isinstance(arg, dict):
-                arg = copy.copy(arg)
-                for k in arg:
-                    v = arg[k]
-                    if isinstance(v, frozendict):
-                        arg[k] = v
-                    elif isinstance(v, dict):
-                        arg[k] = frozendict(v)
-                    elif isinstance(v, list):
-                        v_ = []
-                        for elm in v:
-                            if isinstance(elm, dict):
-                                v_.append(frozendict(elm))
-                            else:
-                                v_.append(elm)
-                        arg[k] = tuple(v_)
-                args_.append(arg)
-            else:
-                args_.append(arg)
-
-        dict.__init__(new, *args_, **kw)
-        return new
-
-    def __init__(self, *args, **kw):
-        pass
-
-    def __hash__(self):
-        try:
-            return self._cached_hash
-        except AttributeError:
-            h = self._cached_hash = hash(tuple(sorted(self.items())))
-            return h
-
-    def __repr__(self):
-        dict_repr = dict.__repr__(self)
-        return f"frozendict({dict_repr})"
 
 
 def make_quoted(s):
@@ -919,7 +861,7 @@ class Edge(Common):
 
         indent_str = self.get_indent(indent, indent_level)
 
-        if isinstance(src, frozendict):
+        if isinstance(src, FrozenDict):
             sgraph = Subgraph(obj_dict=src)
             edge = [
                 sgraph.to_string(
@@ -936,7 +878,7 @@ class Edge(Common):
         else:
             edge.append("--")
 
-        if isinstance(dst, frozendict):
+        if isinstance(dst, FrozenDict):
             sgraph = Subgraph(obj_dict=dst)
             edge.append(
                 sgraph.to_string(

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -11,6 +11,7 @@ import os
 import re
 import subprocess
 import sys
+import warnings
 
 import pydot
 import pydot.dot_parser
@@ -127,6 +128,19 @@ DEFAULT_PROGRAMS = {
     "fdp",
     "sfdp",
 }
+
+
+class frozendict(FrozenDict):
+    """Deprecated alias for pydot.classes.FrozenDict."""
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            f"{self.__class__.__name__} is deprecated. "
+            "Use pydot.classes.FrozenDict instead.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(self, *args, **kwargs)
 
 
 def __generate_attribute_methods(Klass, attrs):

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -34,6 +34,7 @@ from pyparsing import (
 )
 
 import pydot
+from pydot.classes import FrozenDict
 
 __author__ = ["Michael Krause", "Ero Carrera"]
 __license__ = "MIT"
@@ -132,7 +133,7 @@ def update_parent_graph_hierarchy(g, parent_graph=None, level=0):
         parent_graph = g
 
     for key_name in ("edges",):
-        if isinstance(g, pydot.frozendict):
+        if isinstance(g, FrozenDict):
             item_dict = g
         else:
             item_dict = g.obj_dict
@@ -158,7 +159,7 @@ def update_parent_graph_hierarchy(g, parent_graph=None, level=0):
                             (pydot.Graph, pydot.Subgraph, pydot.Cluster),
                         ):
                             vertex.set_parent_graph(parent_graph)
-                        if isinstance(vertex, pydot.frozendict):
+                        if isinstance(vertex, FrozenDict):
                             if vertex["parent_graph"] is g:
                                 pass
                             else:
@@ -300,7 +301,7 @@ def push_edge_stmt(s, loc, toks):
     e = []
 
     if isinstance(toks[0][0], pydot.Graph):
-        n_prev = pydot.frozendict(toks[0][0].obj_dict)
+        n_prev = FrozenDict(toks[0][0].obj_dict)
     else:
         n_prev = toks[0][0] + do_node_ports(toks[0])
 
@@ -311,9 +312,7 @@ def push_edge_stmt(s, loc, toks):
             e.append(pydot.Edge(n_prev, n_next[0] + n_next_port, **attrs))
 
     elif isinstance(toks[2][0], pydot.Graph):
-        e.append(
-            pydot.Edge(n_prev, pydot.frozendict(toks[2][0].obj_dict), **attrs)
-        )
+        e.append(pydot.Edge(n_prev, FrozenDict(toks[2][0].obj_dict), **attrs))
 
     elif isinstance(toks[2][0], pydot.Node):
         node = toks[2][0]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2024 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+import pytest
+
+
+@pytest.fixture
+def objdict():
+    return {
+        "attributes": {},
+        "name": "G",
+        "type": "graph",
+        "strict": False,
+        "suppress_disconnected": False,
+        "simplify": False,
+        "current_child_sequence": 3,
+        "nodes": {
+            "3": [
+                {
+                    "attributes": {},
+                    "type": "node",
+                    "parent_graph": None,
+                    "sequence": 1,
+                    "name": "3",
+                    "port": None,
+                }
+            ],
+            "16": [
+                {
+                    "attributes": {},
+                    "type": "node",
+                    "parent_graph": None,
+                    "sequence": 2,
+                    "name": "16",
+                    "port": None,
+                }
+            ],
+        },
+    }

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: 2024 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit testing of `pydot.classes`."""
+
+import pydot
+import pytest
+from pydot.classes import FrozenDict
+
+
+def test_FrozenDict_create(objdict):
+    fd = FrozenDict(objdict)
+    assert isinstance(fd, FrozenDict)
+    assert isinstance(fd["attributes"], FrozenDict)
+    assert isinstance(fd["nodes"], FrozenDict)
+    assert isinstance(fd["nodes"]["3"], tuple)
+    assert isinstance(fd["nodes"]["16"], tuple)
+
+    fd2 = FrozenDict(frozen=fd)
+    assert isinstance(fd2["frozen"], FrozenDict)
+    assert fd == fd2["frozen"]
+
+
+def test_FrozenDict_modify(objdict):
+    fd = FrozenDict(objdict)
+
+    with pytest.raises(AttributeError):
+        fd.clear()
+
+    with pytest.raises(AttributeError):
+        fd["nodes"] = None
+
+    with pytest.raises(AttributeError):
+        fd["nodes"].update({"12": [{"name": "12"}]})
+
+    with pytest.raises(AttributeError):
+        fd.popitem()
+
+    with pytest.raises(AttributeError):
+        fd.pop("nodes")
+
+    with pytest.raises(AttributeError):
+        fd.setdefault("edges", None)
+
+    with pytest.raises(AttributeError):
+        del fd["nodes"]
+
+
+def test_FrozenDict_compare():
+    dict_in = {
+        "red": "first",
+        "green": "second",
+        "blue": "third",
+    }
+    fd1 = FrozenDict(dict_in)
+    fd2 = FrozenDict(dict(sorted(dict_in.items())))
+    assert hash(fd1) == hash(tuple(dict_in.items()))
+    assert hash(fd2) != hash(tuple(dict_in.items()))
+    assert fd1 != fd2
+
+    assert fd1 == dict_in
+    assert fd2 == dict_in  # Unfortunate fallback to dict.__eq__
+
+
+def test_frozendict_deprecation(objdict):
+    with pytest.warns(DeprecationWarning):
+        fd = pydot.frozendict(objdict)
+
+    assert isinstance(fd, FrozenDict)

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -17,9 +17,10 @@ def test_FrozenDict_create(objdict):
     assert isinstance(fd["nodes"]["3"], tuple)
     assert isinstance(fd["nodes"]["16"], tuple)
 
-    fd2 = FrozenDict(frozen=fd)
-    assert isinstance(fd2["frozen"], FrozenDict)
-    assert fd == fd2["frozen"]
+    fd2 = FrozenDict((("a", 1), ("b", 2)), obj_dict={"frozen": fd})
+    assert isinstance(fd2["obj_dict"], FrozenDict)
+    assert len(fd2) == 3
+    assert fd == fd2["obj_dict"]["frozen"]
 
 
 def test_FrozenDict_modify(objdict):


### PR DESCRIPTION
This PR pulls the `frozendict` class out of `core.py`, creating a new `classes.py` file to hold it, and gives it the PEP8-compliant class name `FrozenDict`. Along the way, it's significantly cleaned up, streamlined, tweaked, and fully tested (every line covered except the `__repr__` method).

* All of the disabled methods are fully defined, with the proper argument signatures, instead of all being aliased to `_blocked_method`.
* The `__new__` method is streamlined and made more robust, with one initialization bug fixed
* Key sorting is removed from the `__hash__()` method, and `__eq__` / `__ne__` methods are defined so that FrozenDicts with differently-ordered members will test as not equal.
* A full set of basic unit tests cover every line of the `pydot.classes` module except for `FrozenDict.__repr__` (including testing that all of the disabled methods properly raise `AttributeError` on attempts to modify the `FrozenDict`).
* `pydot.core.frozendict` is still defined, as an alias for `pydot.classes.FrozenDict` which creates a `DeprecationWarning` on use.