### PR TITLE
Add an actions/setup-python run to coverage

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -116,6 +116,10 @@ jobs:
       # comments (to avoid publishing multiple comments in the same PR)
       contents: write
     steps:
+      - name: "Install Python"
+        uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+        with:
+          python-version: "3.12"
       - name: "Check out source"
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:


### PR DESCRIPTION
A [recent CI run](https://github.com/pydot/pydot/actions/runs/11367160489/job/31619426031?pr=426) failed when the coverage job tried to install `coverage.py` using Pip, which I guess GitHub now balks at. (Never seen that happen before.) 

To avoid those problems, add an `actions/setup-python` step to the start of the job.