### PR TITLE
Add Python 3.13 to tox, CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,6 +39,7 @@ jobs:
           - {os: windows, can-fail: true}
           - {os: macos, can-fail: true}
         python-version:
+          - "3.13"
           - "3.12"
           - "3.11"
           - "3.10"

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ testpaths = test
 [tox:tox]
 min_version = 4.6.3
 env_list =
+    py313
     py312
     py311
     py310
@@ -50,7 +51,8 @@ commands =
 # For tox-gh
 [gh]
 python =
-    3.12 = ruff-check, py312
+    3.13 = ruff-check, py313
+    3.12 = py312
     3.11 = py311
     3.10 = py310
     3.9 = py39


### PR DESCRIPTION
Python 3.13 is released as of 2024-10-07, so we should test with it.