### PR TITLE
Add initial type annotations

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include *.txt
 include LICENSES/*.txt
 include ChangeLog
 include REUSE.toml
+include py.typed
 prune .github
 exclude .git*
 graft test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,12 +63,14 @@ Changelog = "https://github.com/pydot/pydot/blob/main/ChangeLog"
 dev = [
   'chardet',
   'parameterized',
-  'ruff'
+  'ruff',
+  'mypy',
 ]
 tests = [
   'chardet',
   'parameterized',
   'ruff',
+  'mypy',
   'tox',
   'pytest',
   'pytest-cov',
@@ -84,3 +86,11 @@ exclude = [
 
 [tool.ruff.lint]
 select = ['E', 'F', 'W', 'I', 'UP', 'C4']
+
+[tool.mypy]
+strict = true
+files = "src"
+
+[[tool.mypy.overrides]]
+module = "pydot._vendor.tempfile"
+ignore_errors = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ env_list =
     py39
     py38
     ruff-check
+    mypy-check
 
 [testenv]
 extras = tests
@@ -48,12 +49,18 @@ commands =
     ruff format .
     ruff check --fix .
 
+[testenv:mypy-check]
+skip_install = true
+deps = mypy==1.11.2
+commands =
+    mypy
+
 # For tox-gh
 [gh]
 python =
-    3.13 = ruff-check, py313
+    3.13 = ruff-check, mypy-check, py313
     3.12 = py312
     3.11 = py311
     3.10 = py310
     3.9 = py39
-    3.8 = py38
+    3.8 = mypy-check, py38

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,8 +50,7 @@ commands =
     ruff check --fix .
 
 [testenv:mypy-check]
-skip_install = true
-deps = mypy==1.11.2
+extras = dev
 commands =
     mypy
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,14 +37,14 @@ commands = pytest -n auto --cov {posargs}
 
 [testenv:ruff-check]
 skip_install = true
-deps = ruff==0.4.8
+deps = ruff==0.7.3
 commands = 
     ruff format --diff .
     ruff check . {posargs}
 
 [testenv:ruff-fix]
 skip_install = true
-deps = ruff==0.4.8
+deps = ruff==0.7.3
 commands =
     ruff format .
     ruff check --fix .

--- a/src/pydot/_vendor/tempfile.py
+++ b/src/pydot/_vendor/tempfile.py
@@ -37,6 +37,7 @@ __all__ = [
 # Imports.
 
 import functools as _functools
+from typing import Any, Optional
 import warnings as _warnings
 import io as _io
 import os as _os
@@ -536,8 +537,8 @@ class _TemporaryFileWrapper:
 
 def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
                        newline=None, suffix=None, prefix=None,
-                       dir=None, delete=True, *, errors=None,
-                       delete_on_close=True):
+                       dir: Optional[str] = None, delete=True, *, errors=None,
+                       delete_on_close=True) -> Any:
     """Create and return a temporary file.
     Arguments:
     'prefix', 'suffix', 'dir' -- as for mkstemp.
@@ -936,7 +937,7 @@ class TemporaryDirectory:
     def __repr__(self):
         return "<{} {!r}>".format(self.__class__.__name__, self.name)
 
-    def __enter__(self):
+    def __enter__(self) -> str:
         return self.name
 
     def __exit__(self, exc, value, tb):

--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -5,9 +5,10 @@
 """Frozen dictionaries."""
 
 import copy
+from typing import Any, Tuple
 
 
-class FrozenDict(dict):
+class FrozenDict(dict):  # type: ignore
     """Frozen dictionary, values are immutable after creation.
 
     Extended version of ASPN's Python Cookbook Recipe:
@@ -17,29 +18,29 @@ class FrozenDict(dict):
 
     _block_msg = "A frozendict cannot be modified."
 
-    def __delitem__(self, key):
+    def __delitem__(self, key: Any) -> None:
         raise AttributeError(self._block_msg)
 
-    def __setitem__(self, key, value):
+    def __setitem__(self, key: Any, value: Any) -> None:
         raise AttributeError(self._block_msg)
 
-    def clear(self):
+    def clear(self) -> None:
         raise AttributeError(self._block_msg)
 
-    def pop(self, key, default=None):
+    def pop(self, key: Any, default: Any = None) -> None:
         raise AttributeError(self._block_msg)
 
-    def popitem(self):
+    def popitem(self) -> Tuple[Any, Any]:
         raise AttributeError(self._block_msg)
 
-    def setdefault(self, key, default=None):
+    def setdefault(self, key: Any, default: Any = None) -> None:
         raise AttributeError(self._block_msg)
 
-    def update(self, *E, **F):
+    def update(self, *E: Any, **F: Any) -> None:
         raise AttributeError(self._block_msg)
 
     @staticmethod
-    def _freeze_arg(in_arg):
+    def _freeze_arg(in_arg: Any) -> Any:
         if not isinstance(in_arg, dict):
             return in_arg
         arg = copy.copy(in_arg)
@@ -54,30 +55,30 @@ class FrozenDict(dict):
                 )
         return arg
 
-    def __new__(cls, *args, **kw):
+    def __new__(cls, *args: Any, **kw: Any) -> Any:
         new = dict.__new__(cls)
         args_ = [cls._freeze_arg(arg) for arg in args]
         dict.__init__(new, *args_, **cls._freeze_arg(kw))
         return new
 
-    def __init__(self, *args, **kw):
+    def __init__(self, *args: Any, **kw: Any):
         pass
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if isinstance(other, self.__class__):
             return hash(self) == hash(other)
         return NotImplemented
 
-    def __ne__(self, other):
+    def __ne__(self, other: Any) -> bool:
         return not self == other
 
-    def __hash__(self):
+    def __hash__(self) -> int:  # type: ignore
         try:
-            return self._cached_hash
+            return self._cached_hash  # type: ignore
         except AttributeError:
             self._cached_hash = hash(tuple(self.items()))
             return self._cached_hash
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         dict_repr = dict.__repr__(self)
         return f"FrozenDict({dict_repr})"

--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -5,9 +5,10 @@
 """Frozen dictionaries."""
 
 import copy
-from typing import Any, Dict, Tuple, TypeAlias
+from typing import Any, Dict, Tuple
 
-AttributeDict: TypeAlias = Dict[str, Any]
+# Backwards-compatible typing alias
+AttributeDict = Dict[str, Any]
 
 
 class FrozenDict(dict):  # type: ignore

--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -5,7 +5,9 @@
 """Frozen dictionaries."""
 
 import copy
-from typing import Any, Tuple
+from typing import Any, Dict, Tuple, TypeAlias
+
+AttributeDict: TypeAlias = Dict[str, Any]
 
 
 class FrozenDict(dict):  # type: ignore

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -384,7 +384,7 @@ def quote_attr_if_necessary(s: str) -> str:
     return make_quoted(s)
 
 
-def graph_from_dot_data(s: str) -> Optional[List[ParseResults]]:
+def graph_from_dot_data(s: str) -> Optional[List["pydot.Dot"]]:
     """Load graphs from DOT description in string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.
@@ -401,7 +401,7 @@ def graph_from_dot_data(s: str) -> Optional[List[ParseResults]]:
 
 def graph_from_dot_file(
     path: Union[str, bytes], encoding: Optional[str] = None
-) -> Optional[List[ParseResults]]:
+) -> Optional[List["pydot.Dot"]]:
     """Load graphs from DOT file at `path`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -19,7 +19,7 @@ from pyparsing import ParseResults
 import pydot
 import pydot.dot_parser
 from pydot._vendor import tempfile
-from pydot.classes import FrozenDict
+from pydot.classes import AttributeDict, FrozenDict
 
 _logger = logging.getLogger(__name__)
 _logger.debug("pydot core module initializing")
@@ -548,11 +548,11 @@ class Common:
     this one.
     """
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> AttributeDict:
         dict = copy.copy(self.obj_dict)
         return dict
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: AttributeDict) -> None:
         self.obj_dict = state
 
     def set_parent_graph(self, parent_graph: Optional["Common"]) -> None:
@@ -598,7 +598,7 @@ class Common:
         """
         return self.obj_dict["attributes"].get(name, None)
 
-    def get_attributes(self) -> Optional[Dict[str, Any]]:
+    def get_attributes(self) -> Optional[AttributeDict]:
         """Get attributes of the object"""
         return self.obj_dict["attributes"]  # type: ignore
 
@@ -661,7 +661,7 @@ class Node(Common):
     def __init__(
         self,
         name: str = "",
-        obj_dict: Optional[Dict[str, Any]] = None,
+        obj_dict: Optional[AttributeDict] = None,
         **attrs: Any,
     ) -> None:
         #
@@ -776,7 +776,7 @@ class Edge(Common):
         self,
         src: Any = "",
         dst: Any = "",
-        obj_dict: Optional[Dict[str, Any]] = None,
+        obj_dict: Optional[AttributeDict] = None,
         **attrs: Any,
     ) -> None:
         self.obj_dict = {}
@@ -953,7 +953,7 @@ class Graph(Common):
     def __init__(
         self,
         graph_name: str = "G",
-        obj_dict: Optional[Dict[str, Any]] = None,
+        obj_dict: Optional[AttributeDict] = None,
         graph_type: str = "digraph",
         strict: bool = False,
         suppress_disconnected: bool = False,
@@ -1552,7 +1552,7 @@ class Subgraph(Graph):
     def __init__(
         self,
         graph_name: str = "",
-        obj_dict: Optional[Dict[str, Any]] = None,
+        obj_dict: Optional[AttributeDict] = None,
         suppress_disconnected: bool = False,
         simplify: bool = False,
         **attrs: Any,
@@ -1605,7 +1605,7 @@ class Cluster(Graph):
     def __init__(
         self,
         graph_name: str = "subG",
-        obj_dict: Optional[Dict[str, Any]] = None,
+        obj_dict: Optional[AttributeDict] = None,
         suppress_disconnected: bool = False,
         simplify: bool = False,
         **attrs: Any,
@@ -1644,7 +1644,7 @@ class Dot(Graph):
         self.formats = OUTPUT_FORMATS
         self.prog = "dot"
 
-    def __getstate__(self) -> Dict[str, Any]:
+    def __getstate__(self) -> AttributeDict:
         state = {
             "obj_dict": copy.copy(self.obj_dict),
             "prog": self.prog,
@@ -1653,7 +1653,7 @@ class Dot(Graph):
         }
         return state
 
-    def __setstate__(self, state: Dict[str, Any]) -> None:
+    def __setstate__(self, state: AttributeDict) -> None:
         if "obj_dict" not in state:
             # Backwards compatibility for old picklings
             state = {"obj_dict": state}

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -12,9 +12,7 @@ import re
 import subprocess
 import sys
 import warnings
-from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
-
-from pyparsing import ParseResults
+from typing import Any, List, Optional, Sequence, Set, Tuple, Type, Union
 
 import pydot
 import pydot.dot_parser

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -12,6 +12,9 @@ import re
 import subprocess
 import sys
 import warnings
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple, Type, Union
+
+from pyparsing import ParseResults
 
 import pydot
 import pydot.dot_parser
@@ -133,7 +136,7 @@ DEFAULT_PROGRAMS = {
 class frozendict(FrozenDict):
     """Deprecated alias for pydot.classes.FrozenDict."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any):
         warnings.warn(
             f"{self.__class__.__name__} is deprecated. "
             "Use pydot.classes.FrozenDict instead.",
@@ -143,32 +146,39 @@ class frozendict(FrozenDict):
         super().__init__(self, *args, **kwargs)
 
 
-def __generate_attribute_methods(Klass, attrs):
+def __generate_attribute_methods(
+    Klass: Type["Common"], attrs: Set[str]
+) -> None:
     """Generate setter and getter methods for attributes."""
     for attr in attrs:
         # Generate all the Getter methods.
         #
-        def __getter(self, _attr=attr):
+        def __getter(self: Any, _attr: str = attr) -> Any:
             return self.get(_attr)
 
         setattr(Klass, f"get_{attr}", __getter)
 
         # Generate all the Setter methods.
         #
-        def __setter(self, *args, _attr=attr):
+        def __setter(self: Any, *args: Any, _attr: str = attr) -> Any:
             return self.set(_attr, *args)
 
         setattr(Klass, f"set_{attr}", __setter)
 
 
-def __generate_format_methods(Klass):
+def __generate_format_methods(Klass: type) -> None:
     """Generate create_ and write_ methods for formats."""
     # Automatically creates all
     # the methods enabling the creation
     # of output in any of the supported formats.
     for frmt in OUTPUT_FORMATS:
 
-        def __create_method(self, f=frmt, prog=None, encoding=None):
+        def __create_method(
+            self: Any,
+            f: str = frmt,
+            prog: Optional[str] = None,
+            encoding: Optional[str] = None,
+        ) -> Any:
             """Refer to docstring of method `create`."""
             return self.create(format=f, prog=prog, encoding=encoding)
 
@@ -176,35 +186,43 @@ def __generate_format_methods(Klass):
 
     for frmt in OUTPUT_FORMATS ^ {"raw"}:
 
-        def __write_method(self, path, f=frmt, prog=None, encoding=None):
+        def __write_method(
+            self: Any,
+            path: str,
+            f: str = frmt,
+            prog: Optional[str] = None,
+            encoding: Optional[str] = None,
+        ) -> None:
             """Refer to docstring of method `write`."""
             self.write(path, format=f, prog=prog, encoding=encoding)
 
         setattr(Klass, f"write_{frmt}", __write_method)
 
 
-def is_windows():
-    # type: () -> bool
+def is_windows() -> bool:
     return os.name == "nt"
 
 
-def is_anaconda():
-    # type: () -> bool
+def is_anaconda() -> bool:
     import glob
 
     conda_pattern = os.path.join(sys.prefix, "conda-meta\\graphviz*.json")
     return glob.glob(conda_pattern) != []
 
 
-def get_executable_extension():
-    # type: () -> str
+def get_executable_extension() -> str:
     if is_windows():
         return ".bat" if is_anaconda() else ".exe"
     else:
         return ""
 
 
-def call_graphviz(program, arguments, working_dir, **kwargs):
+def call_graphviz(
+    program: str,
+    arguments: List[str],
+    working_dir: Union[str, bytes],
+    **kwargs: Any,
+) -> Tuple[str, str, "subprocess.Popen[str]"]:
     # explicitly inherit `$PATH`, on Windows too,
     # with `shell=False`
 
@@ -237,7 +255,7 @@ def call_graphviz(program, arguments, working_dir, **kwargs):
     return stdout_data, stderr_data, process
 
 
-def make_quoted(s):
+def make_quoted(s: str) -> str:
     """Transform a string into a quoted string, escaping specials."""
     replace = {
         ord('"'): r"\"",
@@ -260,7 +278,7 @@ id_re_alpha_nums_with_ports = re.compile(
 id_re_with_port = re.compile(r"^([^:]*):([^:]*)$")
 
 
-def any_needs_quotes(s):
+def any_needs_quotes(s: str) -> Optional[bool]:
     """Determine if a string needs to be quoted.
 
     Returns True, False, or None if the result is indeterminate.
@@ -285,7 +303,7 @@ def any_needs_quotes(s):
     return None
 
 
-def id_needs_quotes(s):
+def id_needs_quotes(s: str) -> bool:
     """Checks whether a string is a dot language ID.
 
     It will check whether the string is solely composed
@@ -322,7 +340,9 @@ def id_needs_quotes(s):
     return True
 
 
-def quote_id_if_necessary(s, unquoted_keywords=None):
+def quote_id_if_necessary(
+    s: str, unquoted_keywords: Optional[Sequence[str]] = None
+) -> str:
     """Enclose identifier in quotes, if needed."""
     unquoted = [
         w.lower() for w in list(unquoted_keywords if unquoted_keywords else [])
@@ -346,7 +366,7 @@ def quote_id_if_necessary(s, unquoted_keywords=None):
     return s
 
 
-def quote_attr_if_necessary(s):
+def quote_attr_if_necessary(s: str) -> str:
     """Enclose attribute value in quotes, if needed."""
     if isinstance(s, bool):
         return str(s).lower()
@@ -364,7 +384,7 @@ def quote_attr_if_necessary(s):
     return make_quoted(s)
 
 
-def graph_from_dot_data(s):
+def graph_from_dot_data(s: str) -> Optional[List[ParseResults]]:
     """Load graphs from DOT description in string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.
@@ -379,7 +399,9 @@ def graph_from_dot_data(s):
     return pydot.dot_parser.parse_dot_data(s)
 
 
-def graph_from_dot_file(path, encoding=None):
+def graph_from_dot_file(
+    path: Union[str, bytes], encoding: Optional[str] = None
+) -> Optional[List[ParseResults]]:
     """Load graphs from DOT file at `path`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.
@@ -398,7 +420,9 @@ def graph_from_dot_file(path, encoding=None):
     return graphs
 
 
-def graph_from_edges(edge_list, node_prefix="", directed=False):
+def graph_from_edges(
+    edge_list: Sequence[Any], node_prefix: str = "", directed: bool = False
+) -> "pydot.Dot":
     """Creates a basic graph out of an edge list.
 
     The edge list has to be a list of tuples representing
@@ -432,7 +456,11 @@ def graph_from_edges(edge_list, node_prefix="", directed=False):
     return graph
 
 
-def graph_from_adjacency_matrix(matrix, node_prefix="", directed=False):
+def graph_from_adjacency_matrix(
+    matrix: Sequence[Sequence[Any]],
+    node_prefix: str = "",
+    directed: bool = False,
+) -> "Dot":
     """Creates a basic graph out of an adjacency matrix.
 
     The matrix has to be a list of rows of values
@@ -471,7 +499,11 @@ def graph_from_adjacency_matrix(matrix, node_prefix="", directed=False):
     return graph
 
 
-def graph_from_incidence_matrix(matrix, node_prefix="", directed=False):
+def graph_from_incidence_matrix(
+    matrix: Sequence[Sequence[Any]],
+    node_prefix: str = "",
+    directed: bool = False,
+) -> "Dot":
     """Creates a basic graph out of an incidence matrix.
 
     The matrix has to be a list of rows of values
@@ -516,33 +548,33 @@ class Common:
     this one.
     """
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         dict = copy.copy(self.obj_dict)
         return dict
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         self.obj_dict = state
 
-    def set_parent_graph(self, parent_graph):
+    def set_parent_graph(self, parent_graph: Optional["Common"]) -> None:
         self.obj_dict["parent_graph"] = parent_graph
 
-    def get_parent_graph(self):
-        return self.obj_dict.get("parent_graph", None)
+    def get_parent_graph(self) -> Optional["Graph"]:
+        return self.obj_dict.get("parent_graph", None)  # type: ignore
 
-    def get_top_graph_type(self):
+    def get_top_graph_type(self) -> Optional[str]:
         """Find the topmost parent graph type for the current object."""
         parent = self.get_parent_graph()
         if parent is None:
             return None
-        while True:
+        while True and parent is not None:
             parent_ = parent.get_parent_graph()
             if parent_ == parent:
                 break
             parent = parent_
 
-        return parent.obj_dict["type"]
+        return parent.obj_dict["type"]  # type: ignore
 
-    def set(self, name, value):
+    def set(self, name: str, value: Any) -> None:
         """Set an attribute value by name.
 
         Given an attribute 'name' it will set its value to 'value'.
@@ -554,7 +586,7 @@ class Common:
         """
         self.obj_dict["attributes"][name] = value
 
-    def get(self, name):
+    def get(self, name: str) -> Any:
         """Get an attribute value by name.
 
         Given an attribute 'name' it will get its value.
@@ -566,20 +598,20 @@ class Common:
         """
         return self.obj_dict["attributes"].get(name, None)
 
-    def get_attributes(self):
+    def get_attributes(self) -> Optional[Dict[str, Any]]:
         """Get attributes of the object"""
-        return self.obj_dict["attributes"]
+        return self.obj_dict["attributes"]  # type: ignore
 
-    def set_sequence(self, seq):
+    def set_sequence(self, seq: Optional[int]) -> None:
         """Set sequence"""
         self.obj_dict["sequence"] = seq
 
-    def get_sequence(self):
+    def get_sequence(self) -> Optional[int]:
         """Get sequence"""
-        return self.obj_dict["sequence"]
+        return self.obj_dict["sequence"]  # type: ignore
 
     @staticmethod
-    def get_indent(indent, indent_level):
+    def get_indent(indent: Any, indent_level: int) -> str:
         if isinstance(indent, (int, float)):
             indent_str = " " * int(indent)
         else:
@@ -587,7 +619,7 @@ class Common:
         return indent_str * indent_level
 
     @staticmethod
-    def _format_attr(key: str, value):
+    def _format_attr(key: str, value: Any) -> str:
         """Turn a key-value pair into an attribute, properly quoted."""
         if value == "":
             value = '""'
@@ -595,14 +627,14 @@ class Common:
             return f"{key}={quote_attr_if_necessary(value)}"
         return key
 
-    def formatted_attr_list(self):
+    def formatted_attr_list(self) -> List[str]:
         """Return a list of the class's attributes as formatted strings."""
         return [
             self._format_attr(k, v)
             for k, v in self.obj_dict["attributes"].items()
         ]
 
-    def attrs_string(self, prefix=""):
+    def attrs_string(self, prefix: str = "") -> str:
         """Format the current attributes list for output.
 
         The `prefix` string will be prepended if and only if some
@@ -626,7 +658,12 @@ class Node(Common):
     be supported.
     """
 
-    def __init__(self, name="", obj_dict=None, **attrs):
+    def __init__(
+        self,
+        name: str = "",
+        obj_dict: Optional[Dict[str, Any]] = None,
+        **attrs: Any,
+    ) -> None:
         #
         # Nodes will take attributes of
         # all other types because the defaults
@@ -660,22 +697,22 @@ class Node(Common):
             self.obj_dict["name"] = name
             self.obj_dict["port"] = port
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.to_string()
 
-    def set_name(self, node_name):
+    def set_name(self, node_name: Optional[str]) -> None:
         """Set the node's name."""
         self.obj_dict["name"] = node_name
 
-    def get_name(self):
+    def get_name(self) -> str:
         """Get the node's name."""
-        return self.obj_dict["name"]
+        return self.obj_dict["name"]  # type: ignore
 
-    def get_port(self):
+    def get_port(self) -> Optional[str]:
         """Get the node's port."""
-        return self.obj_dict["port"]
+        return self.obj_dict["port"]  # type: ignore
 
-    def add_style(self, style):
+    def add_style(self, style: str) -> None:
         styles = self.obj_dict["attributes"].get("style", None)
         if not styles and style:
             styles = [style]
@@ -685,7 +722,7 @@ class Node(Common):
 
         self.obj_dict["attributes"]["style"] = ",".join(styles)
 
-    def to_string(self, indent="", indent_level=1):
+    def to_string(self, indent: Any = "", indent_level: int = 1) -> str:
         """Return string representation of node in DOT language."""
         indent_str = self.get_indent(indent, indent_level)
 
@@ -735,7 +772,13 @@ class Edge(Common):
 
     """
 
-    def __init__(self, src="", dst="", obj_dict=None, **attrs):
+    def __init__(
+        self,
+        src: Any = "",
+        dst: Any = "",
+        obj_dict: Optional[Dict[str, Any]] = None,
+        **attrs: Any,
+    ) -> None:
         self.obj_dict = {}
         if isinstance(src, (Node, Subgraph, Cluster)):
             src = src.get_name()
@@ -752,21 +795,21 @@ class Edge(Common):
         else:
             self.obj_dict = obj_dict
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.to_string()
 
-    def get_source(self):
+    def get_source(self) -> Optional[str]:
         """Get the edges source node name."""
-        return self.obj_dict["points"][0]
+        return self.obj_dict["points"][0]  # type: ignore
 
-    def get_destination(self):
+    def get_destination(self) -> Optional[str]:
         """Get the edge's destination node name."""
-        return self.obj_dict["points"][1]
+        return self.obj_dict["points"][1]  # type: ignore
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(hash(self.get_source()) + hash(self.get_destination()))
 
-    def __eq__(self, edge):
+    def __eq__(self, edge: object) -> bool:
         """Compare two edges.
 
         If the parent graph is directed, arcs linking
@@ -802,7 +845,7 @@ class Edge(Common):
 
         return False
 
-    def parse_node_ref(self, node_str):
+    def parse_node_ref(self, node_str: Any) -> Any:
         if not isinstance(node_str, str):
             return node_str
 
@@ -829,7 +872,7 @@ class Edge(Common):
 
         return quote_id_if_necessary(node_str)
 
-    def to_string(self, indent="", indent_level=1):
+    def to_string(self, indent: Any = "", indent_level: int = 1) -> str:
         """Return string representation of edge in DOT language."""
         src = self.parse_node_ref(self.get_source())
         dst = self.parse_node_ref(self.get_destination())
@@ -909,14 +952,14 @@ class Graph(Common):
 
     def __init__(
         self,
-        graph_name="G",
-        obj_dict=None,
-        graph_type="digraph",
-        strict=False,
-        suppress_disconnected=False,
-        simplify=False,
-        **attrs,
-    ):
+        graph_name: str = "G",
+        obj_dict: Optional[Dict[str, Any]] = None,
+        graph_type: str = "digraph",
+        strict: bool = False,
+        suppress_disconnected: bool = False,
+        simplify: bool = False,
+        **attrs: Any,
+    ) -> None:
         if obj_dict is not None:
             self.obj_dict = obj_dict
 
@@ -945,16 +988,16 @@ class Graph(Common):
 
             self.set_parent_graph(self)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.to_string()
 
-    def get_graph_type(self):
-        return self.obj_dict["type"]
+    def get_graph_type(self) -> Optional[str]:
+        return self.obj_dict["type"]  # type: ignore
 
-    def set_graph_defaults(self, **attrs):
+    def set_graph_defaults(self, **attrs: Any) -> None:
         self.add_node(Node("graph", **attrs))
 
-    def get_graph_defaults(self, **attrs):
+    def get_graph_defaults(self, **attrs: Any) -> Any:
         graph_nodes = self.get_node("graph")
 
         if isinstance(graph_nodes, (list, tuple)):
@@ -962,7 +1005,7 @@ class Graph(Common):
 
         return graph_nodes.get_attributes()
 
-    def set_node_defaults(self, **attrs):
+    def set_node_defaults(self, **attrs: Any) -> None:
         """Define default node attributes.
 
         These attributes only apply to nodes added to the graph after
@@ -970,7 +1013,7 @@ class Graph(Common):
         """
         self.add_node(Node("node", **attrs))
 
-    def get_node_defaults(self, **attrs):
+    def get_node_defaults(self, **attrs: Any) -> Any:
         graph_nodes = self.get_node("node")
 
         if isinstance(graph_nodes, (list, tuple)):
@@ -978,10 +1021,10 @@ class Graph(Common):
 
         return graph_nodes.get_attributes()
 
-    def set_edge_defaults(self, **attrs):
+    def set_edge_defaults(self, **attrs: Any) -> None:
         self.add_node(Node("edge", **attrs))
 
-    def get_edge_defaults(self, **attrs):
+    def get_edge_defaults(self, **attrs: Any) -> Any:
         graph_nodes = self.get_node("edge")
 
         if isinstance(graph_nodes, (list, tuple)):
@@ -989,7 +1032,7 @@ class Graph(Common):
 
         return graph_nodes.get_attributes()
 
-    def set_simplify(self, simplify):
+    def set_simplify(self, simplify: bool) -> None:
         """Set whether to simplify or not.
 
         If True it will avoid displaying equal edges, i.e.
@@ -998,44 +1041,44 @@ class Graph(Common):
         """
         self.obj_dict["simplify"] = simplify
 
-    def get_simplify(self):
+    def get_simplify(self) -> Optional[bool]:
         """Get whether to simplify or not.
 
         Refer to set_simplify for more information.
         """
-        return self.obj_dict["simplify"]
+        return self.obj_dict["simplify"]  # type: ignore
 
-    def set_type(self, graph_type):
+    def set_type(self, graph_type: str) -> None:
         """Set the graph's type, 'graph' or 'digraph'."""
         self.obj_dict["type"] = graph_type
 
-    def get_type(self):
+    def get_type(self) -> Optional[str]:
         """Get the graph's type, 'graph' or 'digraph'."""
-        return self.obj_dict["type"]
+        return self.obj_dict["type"]  # type: ignore
 
-    def set_name(self, graph_name):
+    def set_name(self, graph_name: str) -> None:
         """Set the graph's name."""
         self.obj_dict["name"] = graph_name
 
-    def get_name(self):
+    def get_name(self) -> Optional[str]:
         """Get the graph's name."""
-        return self.obj_dict["name"]
+        return self.obj_dict["name"]  # type: ignore
 
-    def set_strict(self, val):
+    def set_strict(self, val: bool) -> None:
         """Set graph to 'strict' mode.
 
         This option is only valid for top level graphs.
         """
         self.obj_dict["strict"] = val
 
-    def get_strict(self, val):
+    def get_strict(self, val: Any) -> Optional[bool]:
         """Get graph's 'strict' mode (True, False).
 
         This option is only valid for top level graphs.
         """
-        return self.obj_dict["strict"]
+        return self.obj_dict["strict"]  # type: ignore
 
-    def set_suppress_disconnected(self, val):
+    def set_suppress_disconnected(self, val: str) -> None:
         """Suppress disconnected nodes in the output graph.
 
         This option will skip nodes in
@@ -1046,19 +1089,19 @@ class Graph(Common):
         """
         self.obj_dict["suppress_disconnected"] = val
 
-    def get_suppress_disconnected(self, val):
+    def get_suppress_disconnected(self, val: Any) -> Optional[bool]:
         """Get if suppress disconnected is set.
 
         Refer to set_suppress_disconnected for more information.
         """
-        return self.obj_dict["suppress_disconnected"]
+        return self.obj_dict["suppress_disconnected"]  # type: ignore
 
-    def get_next_sequence_number(self):
-        seq = self.obj_dict["current_child_sequence"]
+    def get_next_sequence_number(self) -> int:
+        seq: int = self.obj_dict["current_child_sequence"]
         self.obj_dict["current_child_sequence"] += 1
         return seq
 
-    def add_node(self, graph_node):
+    def add_node(self, graph_node: Node) -> None:
         """Adds a node object to the graph.
 
         It takes a node object as its only argument and returns
@@ -1087,7 +1130,9 @@ class Graph(Common):
 
         graph_node.set_sequence(self.get_next_sequence_number())
 
-    def del_node(self, name, index=None):
+    def del_node(
+        self, name: Union[str, Node], index: Optional[int] = None
+    ) -> bool:
         """Delete a node from the graph.
 
         Given a node's name all node(s) with that same name
@@ -1117,7 +1162,7 @@ class Graph(Common):
 
         return False
 
-    def get_node(self, name):
+    def get_node(self, name: str) -> List[Node]:
         """Retrieve a node from the graph.
 
         Given a node's name the corresponding Node
@@ -1139,17 +1184,17 @@ class Graph(Common):
 
         return match
 
-    def get_nodes(self):
+    def get_nodes(self) -> List[Node]:
         """Get the list of Node instances."""
         return self.get_node_list()
 
-    def get_node_list(self):
+    def get_node_list(self) -> List[Node]:
         """Get the list of Node instances.
 
         This method returns the list of Node instances
         composing the graph.
         """
-        node_objs = []
+        node_objs: List[Node] = []
 
         for node in self.obj_dict["nodes"]:
             obj_dict_list = self.obj_dict["nodes"][node]
@@ -1157,7 +1202,7 @@ class Graph(Common):
 
         return node_objs
 
-    def add_edge(self, graph_edge):
+    def add_edge(self, graph_edge: Edge) -> None:
         """Adds an edge object to the graph.
 
         It takes a edge object as its only argument and returns
@@ -1180,7 +1225,9 @@ class Graph(Common):
         graph_edge.set_sequence(self.get_next_sequence_number())
         graph_edge.set_parent_graph(self.get_parent_graph())
 
-    def del_edge(self, src_or_list, dst=None, index=None):
+    def del_edge(
+        self, src_or_list: Any, dst: Any = None, index: Optional[int] = None
+    ) -> bool:
         """Delete an edge from the graph.
 
         Given an edge's (source, destination) node names all
@@ -1221,7 +1268,7 @@ class Graph(Common):
 
         return False
 
-    def get_edge(self, src_or_list, dst=None):
+    def get_edge(self, src_or_list: Any, dst: Any = None) -> List[Edge]:
         """Retrieved an edge from the graph.
 
         Given an edge's source and destination the corresponding
@@ -1258,10 +1305,10 @@ class Graph(Common):
 
         return match
 
-    def get_edges(self):
+    def get_edges(self) -> List[Edge]:
         return self.get_edge_list()
 
-    def get_edge_list(self):
+    def get_edge_list(self) -> List[Edge]:
         """Get the list of Edge instances.
 
         This method returns the list of Edge instances
@@ -1275,7 +1322,7 @@ class Graph(Common):
 
         return edge_objs
 
-    def add_subgraph(self, sgraph):
+    def add_subgraph(self, sgraph: "Subgraph") -> None:
         """Adds an subgraph object to the graph.
 
         It takes a subgraph object as its only argument and returns
@@ -1299,7 +1346,7 @@ class Graph(Common):
         sgraph.set_sequence(self.get_next_sequence_number())
         sgraph.set_parent_graph(self.get_parent_graph())
 
-    def get_subgraph(self, name):
+    def get_subgraph(self, name: str) -> List["Subgraph"]:
         """Retrieved a subgraph from the graph.
 
         Given a subgraph's name the corresponding
@@ -1319,10 +1366,10 @@ class Graph(Common):
 
         return match
 
-    def get_subgraphs(self):
+    def get_subgraphs(self) -> List["Subgraph"]:
         return self.get_subgraph_list()
 
-    def get_subgraph_list(self):
+    def get_subgraph_list(self) -> List["Subgraph"]:
         """Get the list of Subgraph instances.
 
         This method returns the list of Subgraph instances
@@ -1338,7 +1385,7 @@ class Graph(Common):
 
         return sgraph_objs
 
-    def set_parent_graph(self, parent_graph):
+    def set_parent_graph(self, parent_graph: Optional[Common]) -> None:
         self.obj_dict["parent_graph"] = parent_graph
 
         for k in self.obj_dict["nodes"]:
@@ -1356,7 +1403,9 @@ class Graph(Common):
             for obj in obj_list:
                 Graph(obj_dict=obj).set_parent_graph(parent_graph)
 
-    def to_string(self, indent="", indent_level=0, inline=False):
+    def to_string(
+        self, indent: Any = "", indent_level: int = 0, inline: bool = False
+    ) -> str:
         """Return string representation of graph in DOT language.
 
         @return: graph and subelements
@@ -1403,9 +1452,9 @@ class Graph(Common):
             edge_src_set, edge_dst_set = list(
                 zip(*[obj["points"] for obj in edge_obj_dicts])
             )
-            edge_src_set, edge_dst_set = set(edge_src_set), set(edge_dst_set)
+            edge_src_set, edge_dst_set = set(edge_src_set), set(edge_dst_set)  # type: ignore
         else:
-            edge_src_set, edge_dst_set = set(), set()
+            edge_src_set, edge_dst_set = set(), set()  # type: ignore
 
         node_obj_dicts = []
         for k in self.obj_dict["nodes"]:
@@ -1502,12 +1551,12 @@ class Subgraph(Graph):
     #
     def __init__(
         self,
-        graph_name="",
-        obj_dict=None,
-        suppress_disconnected=False,
-        simplify=False,
-        **attrs,
-    ):
+        graph_name: str = "",
+        obj_dict: Optional[Dict[str, Any]] = None,
+        suppress_disconnected: bool = False,
+        simplify: bool = False,
+        **attrs: Any,
+    ) -> None:
         Graph.__init__(
             self,
             graph_name=graph_name,
@@ -1555,12 +1604,12 @@ class Cluster(Graph):
 
     def __init__(
         self,
-        graph_name="subG",
-        obj_dict=None,
-        suppress_disconnected=False,
-        simplify=False,
-        **attrs,
-    ):
+        graph_name: str = "subG",
+        obj_dict: Optional[Dict[str, Any]] = None,
+        suppress_disconnected: bool = False,
+        simplify: bool = False,
+        **attrs: Any,
+    ) -> None:
         Graph.__init__(
             self,
             graph_name=graph_name,
@@ -1588,14 +1637,14 @@ class Dot(Graph):
     the base class 'Graph'.
     """
 
-    def __init__(self, *argsl, **argsd):
+    def __init__(self, *argsl: Any, **argsd: Any) -> None:
         Graph.__init__(self, *argsl, **argsd)
 
-        self.shape_files = []
+        self.shape_files: List[str] = []
         self.formats = OUTPUT_FORMATS
         self.prog = "dot"
 
-    def __getstate__(self):
+    def __getstate__(self) -> Dict[str, Any]:
         state = {
             "obj_dict": copy.copy(self.obj_dict),
             "prog": self.prog,
@@ -1604,7 +1653,7 @@ class Dot(Graph):
         }
         return state
 
-    def __setstate__(self, state):
+    def __setstate__(self, state: Dict[str, Any]) -> None:
         if "obj_dict" not in state:
             # Backwards compatibility for old picklings
             state = {"obj_dict": state}
@@ -1613,7 +1662,7 @@ class Dot(Graph):
         self.shape_files = state.get("shape_files", [])
         self.formats = state.get("formats", OUTPUT_FORMATS)
 
-    def set_shape_files(self, file_paths):
+    def set_shape_files(self, file_paths: Union[str, Sequence[str]]) -> None:
         """Add the paths of the required image files.
 
         If the graph needs graphic objects to
@@ -1636,7 +1685,7 @@ class Dot(Graph):
         if isinstance(file_paths, (list, tuple)):
             self.shape_files.extend(file_paths)
 
-    def set_prog(self, prog):
+    def set_prog(self, prog: str) -> None:
         """Sets the default program.
 
         Sets the default program in charge of processing
@@ -1644,7 +1693,13 @@ class Dot(Graph):
         """
         self.prog = prog
 
-    def write(self, path, prog=None, format="raw", encoding=None):
+    def write(
+        self,
+        path: Union[str, bytes],
+        prog: Optional[str] = None,
+        format: str = "raw",
+        encoding: Optional[str] = None,
+    ) -> bool:
         """Writes a graph to a file.
 
         Given a filename 'path' it will open/create and truncate
@@ -1678,13 +1733,18 @@ class Dot(Graph):
         else:
             s = self.create(prog, format, encoding=encoding)
             with open(path, mode="wb") as f:
-                f.write(s)
+                f.write(s)  # type: ignore
         return True
 
-    def create(self, prog=None, format="ps", encoding=None):
+    def create(
+        self,
+        prog: Union[List[str], Tuple[str], Optional[str]] = None,
+        format: str = "ps",
+        encoding: Optional[str] = None,
+    ) -> str:
         """Creates and returns a binary image for the graph.
 
-        create will write the graph to a temporary dot file in the
+        create will write the graph to a tempworary dot file in the
         encoding specified by `encoding` and process it with the
         program given by 'prog' (which defaults to 'twopi'), reading
         the binary image output and return it as `bytes`.
@@ -1744,12 +1804,12 @@ class Dot(Graph):
         if isinstance(prog, (list, tuple)):
             prog, args = prog[0], prog[1:]
         else:
-            args = []
+            args = []  # type: ignore
 
         # temp file
         with tempfile.TemporaryDirectory(
             ignore_cleanup_errors=True
-        ) as tmp_dir:
+        ) as tmp_dir:  # type: ignore
             fp = tempfile.NamedTemporaryFile(dir=tmp_dir, delete=False)
             fp.close()
             self.write(fp.name, encoding=encoding)
@@ -1762,7 +1822,7 @@ class Dot(Graph):
                     img_data = img_in.read()
                     img_out.write(img_data)
 
-            arguments = [f"-T{format}"] + args + [fp.name]
+            arguments = [f"-T{format}"] + args + [fp.name]  # type: ignore
 
             try:
                 stdout_data, stderr_data, process = call_graphviz(
@@ -1772,8 +1832,8 @@ class Dot(Graph):
                 )
             except OSError as e:
                 if e.errno == errno.ENOENT:
-                    args = list(e.args)
-                    args[1] = f'"{prog}" not found in path.'
+                    args = list(e.args)  # type: ignore
+                    args[1] = f'"{prog}" not found in path.'  # type: ignore
                     raise OSError(*args)
                 else:
                     raise

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -384,7 +384,7 @@ def quote_attr_if_necessary(s: str) -> str:
     return make_quoted(s)
 
 
-def graph_from_dot_data(s: str) -> Optional[List["pydot.Dot"]]:
+def graph_from_dot_data(s: str) -> Optional[List["Dot"]]:
     """Load graphs from DOT description in string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.
@@ -401,7 +401,7 @@ def graph_from_dot_data(s: str) -> Optional[List["pydot.Dot"]]:
 
 def graph_from_dot_file(
     path: Union[str, bytes], encoding: Optional[str] = None
-) -> Optional[List["pydot.Dot"]]:
+) -> Optional[List["Dot"]]:
     """Load graphs from DOT file at `path`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.
@@ -422,7 +422,7 @@ def graph_from_dot_file(
 
 def graph_from_edges(
     edge_list: Sequence[Any], node_prefix: str = "", directed: bool = False
-) -> "pydot.Dot":
+) -> "Dot":
     """Creates a basic graph out of an edge list.
 
     The edge list has to be a list of tuples representing

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -13,8 +13,7 @@ Fixes by: Ero Carrera <ero.carrera@gmail.com>
 """
 
 import logging
-from typing import Any, Dict, List, Union
-from typing import Optional as Optional_
+import typing as T
 
 from pyparsing import (
     CaselessLiteral,
@@ -69,7 +68,7 @@ class P_AttrList:
 
 
 class DefaultStatement(P_AttrList):
-    def __init__(self, default_type: str, attrs: Any) -> None:
+    def __init__(self, default_type: str, attrs: T.Any) -> None:
         self.default_type = default_type
         self.attrs = attrs
 
@@ -80,7 +79,7 @@ class DefaultStatement(P_AttrList):
 
 def push_top_graph_stmt(
     s: str, loc: int, toks: ParseResults
-) -> Union[List["pydot.Dot"], "pydot.Dot"]:
+) -> T.Union[T.List["pydot.Dot"], "pydot.Dot"]:
     attrs = {}
     top_graphs = []
     g: pydot.Dot = None  # type: ignore
@@ -134,7 +133,7 @@ def push_top_graph_stmt(
 
 
 def update_parent_graph_hierarchy(
-    g: Any, parent_graph: Any = None, level: int = 0
+    g: T.Any, parent_graph: T.Any = None, level: int = 0
 ) -> None:
     if parent_graph is None:
         parent_graph = g
@@ -175,7 +174,7 @@ def update_parent_graph_hierarchy(
                                 )
 
 
-def add_defaults(element: Any, defaults: Dict[Any, Any]) -> None:
+def add_defaults(element: T.Any, defaults: T.Dict[T.Any, T.Any]) -> None:
     d = element.__dict__
     for key, value in defaults.items():
         if not d.get(key):
@@ -183,11 +182,11 @@ def add_defaults(element: Any, defaults: Dict[Any, Any]) -> None:
 
 
 def add_elements(
-    g: Any,
-    toks: Union[ParseResults, List[Any]],
-    defaults_graph: Any = None,
-    defaults_node: Any = None,
-    defaults_edge: Any = None,
+    g: T.Any,
+    toks: T.Union[ParseResults, T.List[T.Any]],
+    defaults_graph: T.Any = None,
+    defaults_node: T.Any = None,
+    defaults_edge: T.Any = None,
 ) -> None:
     if defaults_graph is None:
         defaults_graph = {}
@@ -293,7 +292,7 @@ def push_attr_list(s: str, loc: int, toks: ParseResults) -> P_AttrList:
     return p
 
 
-def get_port(node: Any) -> Any:
+def get_port(node: T.Any) -> T.Any:
     if len(node) > 1:
         if isinstance(node[1], ParseResults):
             if len(node[1][0]) == 2:
@@ -303,7 +302,7 @@ def get_port(node: Any) -> Any:
     return None
 
 
-def do_node_ports(node: Any) -> str:
+def do_node_ports(node: T.Any) -> str:
     node_port = ""
     if len(node) > 1:
         node_port = "".join([str(a) + str(b) for a, b in node[1]])
@@ -311,7 +310,9 @@ def do_node_ports(node: Any) -> str:
     return node_port
 
 
-def push_edge_stmt(s: str, loc: int, toks: ParseResults) -> List["pydot.Edge"]:
+def push_edge_stmt(
+    s: str, loc: int, toks: ParseResults
+) -> T.List["pydot.Edge"]:
     tok_attrs = [a for a in toks if isinstance(a, P_AttrList)]
     attrs = {}
     for a in tok_attrs:
@@ -513,7 +514,7 @@ def graph_definition() -> ParserElement:
     return graphparser
 
 
-def parse_dot_data(s: str) -> Optional_[List[ParseResults]]:
+def parse_dot_data(s: str) -> T.Optional[T.List[ParseResults]]:
     """Parse DOT description in (unicode) string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -36,7 +36,7 @@ from pyparsing import (
 )
 
 import pydot
-from pydot.classes import FrozenDict
+from pydot.classes import AttributeDict, FrozenDict
 
 __author__ = ["Michael Krause", "Ero Carrera"]
 __license__ = "MIT"
@@ -184,9 +184,9 @@ def add_defaults(element: T.Any, defaults: T.Dict[T.Any, T.Any]) -> None:
 def add_elements(
     g: T.Any,
     toks: T.Union[ParseResults, T.List[T.Any]],
-    defaults_graph: T.Any = None,
-    defaults_node: T.Any = None,
-    defaults_edge: T.Any = None,
+    defaults_graph: T.Optional[AttributeDict] = None,
+    defaults_node: T.Optional[AttributeDict] = None,
+    defaults_edge: T.Optional[AttributeDict] = None,
 ) -> None:
     if defaults_graph is None:
         defaults_graph = {}

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -79,7 +79,7 @@ class DefaultStatement(P_AttrList):
 
 def push_top_graph_stmt(
     s: str, loc: int, toks: ParseResults
-) -> T.Union[T.List["pydot.Dot"], "pydot.Dot"]:
+) -> T.Union[T.List["pydot.core.Dot"], "pydot.core.Dot"]:
     attrs = {}
     top_graphs = []
     g: pydot.Dot = None  # type: ignore
@@ -244,7 +244,9 @@ def add_elements(
             raise ValueError(f"Unknown element statement: {element}")
 
 
-def push_graph_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.Subgraph":
+def push_graph_stmt(
+    s: str, loc: int, toks: ParseResults
+) -> "pydot.core.Subgraph":
     g = pydot.Subgraph("")
     add_elements(g, toks)
     return g
@@ -252,7 +254,7 @@ def push_graph_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.Subgraph":
 
 def push_subgraph_stmt(
     s: str, loc: int, toks: ParseResults
-) -> "pydot.Subgraph":
+) -> "pydot.core.Subgraph":
     g = pydot.Subgraph("")
     for e in toks:
         if len(e) == 3:
@@ -312,7 +314,7 @@ def do_node_ports(node: T.Any) -> str:
 
 def push_edge_stmt(
     s: str, loc: int, toks: ParseResults
-) -> T.List["pydot.Edge"]:
+) -> T.List["pydot.core.Edge"]:
     tok_attrs = [a for a in toks if isinstance(a, P_AttrList)]
     attrs = {}
     for a in tok_attrs:
@@ -366,7 +368,7 @@ def push_edge_stmt(
     return e
 
 
-def push_node_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.Node":
+def push_node_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.core.Node":
     if len(toks) == 2:
         attrs = toks[1].attrs
     else:
@@ -514,7 +516,7 @@ def graph_definition() -> ParserElement:
     return graphparser
 
 
-def parse_dot_data(s: str) -> T.Optional[T.List["pydot.Dot"]]:
+def parse_dot_data(s: str) -> T.Optional[T.List["pydot.core.Dot"]]:
     """Parse DOT description in (unicode) string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -13,6 +13,8 @@ Fixes by: Ero Carrera <ero.carrera@gmail.com>
 """
 
 import logging
+from typing import Any, Dict, List, Union
+from typing import Optional as Optional_
 
 from pyparsing import (
     CaselessLiteral,
@@ -24,6 +26,7 @@ from pyparsing import (
     OneOrMore,
     Optional,
     ParseException,
+    ParserElement,
     ParseResults,
     QuotedString,
     Word,
@@ -45,7 +48,7 @@ _logger.debug("pydot dot_parser module initializing")
 
 
 class P_AttrList:
-    def __init__(self, toks):
+    def __init__(self, toks: ParseResults) -> None:
         self.attrs = {}
         i = 0
 
@@ -60,25 +63,27 @@ class P_AttrList:
 
             self.attrs[attrname] = attrvalue
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = self.__class__.__name__
         return f"{name}({self.attrs!r})"
 
 
 class DefaultStatement(P_AttrList):
-    def __init__(self, default_type, attrs):
+    def __init__(self, default_type: str, attrs: Any) -> None:
         self.default_type = default_type
         self.attrs = attrs
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         name = self.__class__.__name__
         return f"{name}({self.default_type}, {self.attrs!r})"
 
 
-def push_top_graph_stmt(s, loc, toks):
+def push_top_graph_stmt(
+    s: str, loc: int, toks: ParseResults
+) -> Union[List["pydot.Dot"], "pydot.Dot"]:
     attrs = {}
     top_graphs = []
-    g = None
+    g: pydot.Dot = None  # type: ignore
 
     for element in toks:
         if (
@@ -128,7 +133,9 @@ def push_top_graph_stmt(s, loc, toks):
     return top_graphs
 
 
-def update_parent_graph_hierarchy(g, parent_graph=None, level=0):
+def update_parent_graph_hierarchy(
+    g: Any, parent_graph: Any = None, level: int = 0
+) -> None:
     if parent_graph is None:
         parent_graph = g
 
@@ -168,7 +175,7 @@ def update_parent_graph_hierarchy(g, parent_graph=None, level=0):
                                 )
 
 
-def add_defaults(element, defaults):
+def add_defaults(element: Any, defaults: Dict[Any, Any]) -> None:
     d = element.__dict__
     for key, value in defaults.items():
         if not d.get(key):
@@ -176,8 +183,12 @@ def add_defaults(element, defaults):
 
 
 def add_elements(
-    g, toks, defaults_graph=None, defaults_node=None, defaults_edge=None
-):
+    g: Any,
+    toks: Union[ParseResults, List[Any]],
+    defaults_graph: Any = None,
+    defaults_node: Any = None,
+    defaults_edge: Any = None,
+) -> None:
     if defaults_graph is None:
         defaults_graph = {}
     if defaults_node is None:
@@ -201,7 +212,11 @@ def add_elements(
         elif isinstance(element, ParseResults):
             for e in element:
                 add_elements(
-                    g, [e], defaults_graph, defaults_node, defaults_edge
+                    g,
+                    [e],
+                    defaults_graph,
+                    defaults_node,
+                    defaults_edge,
                 )
 
         elif isinstance(element, DefaultStatement):
@@ -230,29 +245,33 @@ def add_elements(
             raise ValueError(f"Unknown element statement: {element}")
 
 
-def push_graph_stmt(s, loc, toks):
+def push_graph_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.Subgraph":
     g = pydot.Subgraph("")
     add_elements(g, toks)
     return g
 
 
-def push_subgraph_stmt(s, loc, toks):
+def push_subgraph_stmt(
+    s: str, loc: int, toks: ParseResults
+) -> "pydot.Subgraph":
     g = pydot.Subgraph("")
     for e in toks:
         if len(e) == 3:
             e[2].set_name(e[1])
             if e[0] == "subgraph":
                 e[2].obj_dict["show_keyword"] = True
-            return e[2]
+            return e[2]  # type: ignore
         else:
             if e[0] == "subgraph":
                 e[1].obj_dict["show_keyword"] = True
-            return e[1]
+            return e[1]  # type: ignore
 
     return g
 
 
-def push_default_stmt(s, loc, toks):
+def push_default_stmt(
+    s: str, loc: int, toks: ParseResults
+) -> DefaultStatement:
     # The pydot class instances should be marked as
     # default statements to be inherited by actual
     # graphs, nodes and edges.
@@ -269,12 +288,12 @@ def push_default_stmt(s, loc, toks):
         raise ValueError(f"Unknown default statement: {toks}")
 
 
-def push_attr_list(s, loc, toks):
+def push_attr_list(s: str, loc: int, toks: ParseResults) -> P_AttrList:
     p = P_AttrList(toks)
     return p
 
 
-def get_port(node):
+def get_port(node: Any) -> Any:
     if len(node) > 1:
         if isinstance(node[1], ParseResults):
             if len(node[1][0]) == 2:
@@ -284,7 +303,7 @@ def get_port(node):
     return None
 
 
-def do_node_ports(node):
+def do_node_ports(node: Any) -> str:
     node_port = ""
     if len(node) > 1:
         node_port = "".join([str(a) + str(b) for a, b in node[1]])
@@ -292,7 +311,7 @@ def do_node_ports(node):
     return node_port
 
 
-def push_edge_stmt(s, loc, toks):
+def push_edge_stmt(s: str, loc: int, toks: ParseResults) -> List["pydot.Edge"]:
     tok_attrs = [a for a in toks if isinstance(a, P_AttrList)]
     attrs = {}
     for a in tok_attrs:
@@ -317,8 +336,9 @@ def push_edge_stmt(s, loc, toks):
     elif isinstance(toks[2][0], pydot.Node):
         node = toks[2][0]
 
+        name_port: str
         if node.get_port() is not None:
-            name_port = node.get_name() + ":" + node.get_port()
+            name_port = node.get_name() + ":" + node.get_port()  # type: ignore
         else:
             name_port = node.get_name()
 
@@ -335,7 +355,7 @@ def push_edge_stmt(s, loc, toks):
             n_next_port = do_node_ports(n_next)
             e.append(pydot.Edge(n_prev, n_next[0] + n_next_port, **attrs))
 
-            n_prev = n_next[0] + n_next_port
+            n_prev = n_next[0] + n_next_port  # type: ignore
     else:
         raise Exception(
             f"Edge target {toks[2][0]} with type {type(toks[2][0])}"
@@ -345,7 +365,7 @@ def push_edge_stmt(s, loc, toks):
     return e
 
 
-def push_node_stmt(s, loc, toks):
+def push_node_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.Node":
     if len(toks) == 2:
         attrs = toks[1].attrs
     else:
@@ -363,7 +383,7 @@ def push_node_stmt(s, loc, toks):
 graphparser = None
 
 
-def graph_definition():
+def graph_definition() -> ParserElement:
     global graphparser
 
     if not graphparser:
@@ -493,7 +513,7 @@ def graph_definition():
     return graphparser
 
 
-def parse_dot_data(s):
+def parse_dot_data(s: str) -> Optional_[List[ParseResults]]:
     """Parse DOT description in (unicode) string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -514,7 +514,7 @@ def graph_definition() -> ParserElement:
     return graphparser
 
 
-def parse_dot_data(s: str) -> T.Optional[T.List[ParseResults]]:
+def parse_dot_data(s: str) -> T.Optional[T.List["pydot.Dot"]]:
     """Parse DOT description in (unicode) string `s`.
 
     This function is NOT thread-safe due to the internal use of `pyparsing`.

--- a/src/pydot/exceptions.py
+++ b/src/pydot/exceptions.py
@@ -19,8 +19,8 @@ class PydotException(Exception):
 class Error(PydotException):
     """General error handling class."""
 
-    def __init__(self, value):
+    def __init__(self, value: str) -> None:
         self.value = value
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -4,8 +4,9 @@
 
 """Unit testing of `pydot.classes`."""
 
-import pydot
 import pytest
+
+import pydot
 from pydot.classes import FrozenDict
 
 

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -20,8 +20,9 @@ import unittest
 from hashlib import sha256
 
 import chardet
-import pydot
 from parameterized import parameterized
+
+import pydot
 from pydot._vendor import tempfile
 
 TEST_ERROR_DIR = os.getenv("TEST_ERROR_DIR", None)


### PR DESCRIPTION
I've been thinking about adding type annotations and checking to `pydot` for a long time.

For people who don't care, which may be the majority of users (the academic user base), it will make no difference.
But if someone decides to use typing annotations in their project, the lack of them in `pydot` might annoy them.

This is not a full implementation. There's way too much `Any` thrown in as a Band-Aid. My memory is bad, so I had to check some types at runtime to see what flows where. But doing that everywhere takes a little more work. So more work is needed! But it's a first step. And it doesn't affect the runtime (hopefully).

The diff is huge but it's just annotations.

I'll just have to make sure the CI runs smoothly. For now, the type checks would run on the oldest and newest supported version. Python 3.8 is now officially EOL, but even if we drop our support for it soon, it still would be an evil move to break `pydot` for all its users. So we're forced to use annoying imports (`from typing import List -> List[str]` instead of just `list[str]`)

