### PR TITLE
Avoid subprocess window creation within call_graphviz on Windows

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -215,8 +215,11 @@ def call_graphviz(program, arguments, working_dir, **kwargs):
     if arguments is None:
         arguments = []
 
-    if "creationflags" not in kwargs and hasattr(subprocess, 'CREATE_NO_WINDOW'):
-        # Only on Windows OS, specify that the new process shall not create a new window
+    if "creationflags" not in kwargs and hasattr(
+        subprocess, "CREATE_NO_WINDOW"
+    ):
+        # Only on Windows OS:
+        # specify that the new process shall not create a new window
         kwargs.update(creationflags=subprocess.CREATE_NO_WINDOW)
 
     env = {

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -215,6 +215,10 @@ def call_graphviz(program, arguments, working_dir, **kwargs):
     if arguments is None:
         arguments = []
 
+    if "creationflags" not in kwargs and hasattr(subprocess, 'CREATE_NO_WINDOW'):
+        # Only on Windows OS, specify that the new process shall not create a new window
+        kwargs.update(creationflags=subprocess.CREATE_NO_WINDOW)
+
     env = {
         "PATH": os.environ.get("PATH", ""),
         "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),


### PR DESCRIPTION
Hi pydot team,

Thanks for the recent updates to this project which helped [networkx support `pydot` again](https://github.com/networkx/networkx/pull/7204).

### Context

I'm using `pydot` through `networkx` for some python plugins that are added to a C++ host application in the form of a plugin.

In Windows OS, running [`drawing.nx_pydot.graphviz_layout`](https://github.com/networkx/networkx/blob/478183cb7c692a82dd529c58f20d05a17b271242/networkx/drawing/nx_pydot.py#L241) leads to a terminal window appearing and disappearing very quickly. This happens through the execution of [`pydot.core.call_graphviz`](https://github.com/pydot/pydot/blob/95cb51d0afee78cf5083a041b4d24a41f237802b/src/pydot/core.py#L226-L234)'s subprocess call:

https://github.com/pydot/pydot/blob/95cb51d0afee78cf5083a041b4d24a41f237802b/src/pydot/core.py#L226-L234

### Changes in this PR

This PR proposes that when `creationflags` is not provided to `call_graphviz` as a keyword argument, and if [`subprocess.CREATE_NO_WINDOW`](https://docs.python.org/3/library/subprocess.html#subprocess.CREATE_NO_WINDOW) is available (it's part of [Windows OS-only constants](https://docs.python.org/3/library/subprocess.html#windows-constants)), it will be passed as a creation flag to the subprocess call. The python docs state this flag is for:
> A [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen) creationflags parameter to specify that a new process will not create a window.

An example of this change within the host application where I'm using networkx + pydot, selecting and executing the following python snippet:

```python
import networkx as nx
from networkx import drawing
graph = nx.DiGraph({'a':'b'})
positions = drawing.nx_pydot.graphviz_layout(graph, prog='dot')
print(positions)
```

| Before this PR | With this PR |
| ------ | ------ |
| ![call_graphviz_before](https://github.com/user-attachments/assets/06fa3ad6-f9f7-4863-b0c7-d8b467cb9aa4) | ![call_graphviz_after](https://github.com/user-attachments/assets/76bd3719-c4a6-4f48-9785-d09a69f4da37) |

---

Let me know your thoughts,

Thanks!

-Chris