### PR TITLE
Implement .resolve() method for attributes

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1130,7 +1130,9 @@ class Graph(Common):
         self.obj_dict["current_child_sequence"] += 1
         return seq
 
-    def find_default(self, name: str, element_type: str, seq_end: int = -1) -> Any:
+    def find_default(
+        self, name: str, element_type: str, seq_end: int = -1
+    ) -> Any:
         """Find the default value for attribute 'name' on 'element_type'.
 
         If 'seq_end' is set, use it to limit the range of sequence numbers

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1154,7 +1154,7 @@ class Graph(Common):
         if element_type == "graph" and self.get(name) is not None:
             return self.get(name)
         parent = self.get_parent_graph()
-        if parent is not self:
+        if parent and parent is not self:
             return parent.find_default(
                 name, element_type, self.obj_dict["sequence"]
             )


### PR DESCRIPTION
This WIP PR implements a method <code>.resolve(</var>name</var>)</code> for all graph element classes, which can be thought of as "`.get()` with defaults".

Where <code>.get(<var>name</var>)</code> will only look up the value for the <var>name</var> attribute if it's set on the object for which it's called, <code>.resolve(<var>name</var>)</code> will look for that attribute, and if it's not found, walk up the graph hierarchy scanning for a relevant default value. If one is found, that value is returned instead.

Internally, a `.find_default(name, element_type, seq_end)` method on Graph handles walking the hierarchy. It will consider the attributes of any `node`, `edge`, or `graph` nodes that correspond to the type of the current element, and also have lower sequence numbers. (Nodes are checked in reverse sequence order, first one with a matching attribute returns the value.) Any direct graph attributes on the parent graph(s) are also checked, when looking up subgraph attributes.

### Remaining work
- [ ] An open question: **Should** this be a separate method, or should it be an optional feature of `.get()`? e.g. something like <code>.get(<var>name</var>, find_default=True)</code>
- [ ] Tests. There are none, yet, and obviously this is something that needs to be tested very thoroughly to make sure the default-finding logic matches graphviz's own.
