### PR TITLE
Simplify get_top_graph_type with default

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -12,7 +12,7 @@ import re
 import subprocess
 import sys
 import warnings
-from typing import Any, List, Optional, Sequence, Set, Tuple, Type, Union
+from typing import Any, List, Optional, Sequence, Set, Tuple, Type, Union, cast
 
 import pydot
 import pydot.dot_parser
@@ -566,18 +566,17 @@ class Common:
     def get_parent_graph(self) -> Optional["Graph"]:
         return self.obj_dict.get("parent_graph", None)  # type: ignore
 
-    def get_top_graph_type(self) -> Optional[str]:
+    def get_top_graph_type(self, default: str = "graph") -> str:
         """Find the topmost parent graph type for the current object."""
         parent = self.get_parent_graph()
-        if parent is None:
-            return None
         while True and parent is not None:
             parent_ = parent.get_parent_graph()
             if parent_ == parent:
                 break
             parent = parent_
-
-        return parent.obj_dict["type"]  # type: ignore
+        if parent is None:
+            return default
+        return cast("str", parent.obj_dict.get("type", default))
 
     def set(self, name: str, value: Any) -> None:
         """Set an attribute value by name.


### PR DESCRIPTION
To make use of get_top_graph_type simpler for callers, add an optional argument "default", with a default value of "graph". This value will be returned if the element has no identifiable top graph type (e.g. an Edge not yet added to a Graph).

"graph" was chosen as the default (even though the _actual_ default type for graphs is "digraph") because it generally triggers more expansive processing in code that relies on it. The tools to look up edges, for example, will use the endpoints in both orderings, when in an undirected "graph" context.

This also makes the typing easier, as `get_top_graph_type` now returns `str` in all cases.