### PR TITLE
Improve initialization, getters

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1001,13 +1001,9 @@ class Graph(Common):
     def set_graph_defaults(self, **attrs: Any) -> None:
         self.add_node(Node("graph", **attrs))
 
-    def get_graph_defaults(self, **attrs: Any) -> Any:
+    def get_graph_defaults(self) -> Any:
         graph_nodes = self.get_node("graph")
-
-        if isinstance(graph_nodes, (list, tuple)):
-            return [node.get_attributes() for node in graph_nodes]
-
-        return graph_nodes.get_attributes()
+        return [node.get_attributes() for node in graph_nodes]
 
     def set_node_defaults(self, **attrs: Any) -> None:
         """Define default node attributes.
@@ -1017,24 +1013,16 @@ class Graph(Common):
         """
         self.add_node(Node("node", **attrs))
 
-    def get_node_defaults(self, **attrs: Any) -> Any:
+    def get_node_defaults(self) -> Any:
         graph_nodes = self.get_node("node")
-
-        if isinstance(graph_nodes, (list, tuple)):
-            return [node.get_attributes() for node in graph_nodes]
-
-        return graph_nodes.get_attributes()
+        return [node.get_attributes() for node in graph_nodes]
 
     def set_edge_defaults(self, **attrs: Any) -> None:
         self.add_node(Node("edge", **attrs))
 
-    def get_edge_defaults(self, **attrs: Any) -> Any:
+    def get_edge_defaults(self) -> Any:
         graph_nodes = self.get_node("edge")
-
-        if isinstance(graph_nodes, (list, tuple)):
-            return [node.get_attributes() for node in graph_nodes]
-
-        return graph_nodes.get_attributes()
+        return [node.get_attributes() for node in graph_nodes]
 
     def set_simplify(self, simplify: bool) -> None:
         """Set whether to simplify or not.
@@ -1075,7 +1063,7 @@ class Graph(Common):
         """
         self.obj_dict["strict"] = val
 
-    def get_strict(self, val: Any) -> Optional[bool]:
+    def get_strict(self) -> Optional[bool]:
         """Get graph's 'strict' mode (True, False).
 
         This option is only valid for top level graphs.
@@ -1093,7 +1081,7 @@ class Graph(Common):
         """
         self.obj_dict["suppress_disconnected"] = val
 
-    def get_suppress_disconnected(self, val: Any) -> Optional[bool]:
+    def get_suppress_disconnected(self) -> Optional[bool]:
         """Get if suppress disconnected is set.
 
         Refer to set_suppress_disconnected for more information.

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -554,8 +554,8 @@ class Common:
     """
 
     def __getstate__(self) -> AttributeDict:
-        dict = copy.copy(self.obj_dict)
-        return dict
+        _dict = copy.copy(self.obj_dict)
+        return _dict
 
     def __setstate__(self, state: AttributeDict) -> None:
         self.obj_dict = state

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -553,6 +553,9 @@ class Common:
     this one.
     """
 
+    def __init__(self, obj_dict: Optional[AttributeDict] = None) -> None:
+        self.obj_dict: AttributeDict = obj_dict or {}
+
     def __getstate__(self) -> AttributeDict:
         _dict = copy.copy(self.obj_dict)
         return _dict
@@ -668,18 +671,8 @@ class Node(Common):
         obj_dict: Optional[AttributeDict] = None,
         **attrs: Any,
     ) -> None:
-        #
-        # Nodes will take attributes of
-        # all other types because the defaults
-        # for any GraphViz object are dealt with
-        # as if they were Node definitions
-        #
-        if obj_dict is not None:
-            self.obj_dict = obj_dict
-
-        else:
-            self.obj_dict = {}
-
+        super().__init__(obj_dict)
+        if obj_dict is None:
             # Copy the attributes
             #
             self.obj_dict["attributes"] = dict(attrs)
@@ -783,21 +776,18 @@ class Edge(Common):
         obj_dict: Optional[AttributeDict] = None,
         **attrs: Any,
     ) -> None:
-        self.obj_dict = {}
-        if isinstance(src, (Node, Subgraph, Cluster)):
-            src = src.get_name()
-        if isinstance(dst, (Node, Subgraph, Cluster)):
-            dst = dst.get_name()
-        points = (src, dst)
-        self.obj_dict["points"] = points
+        super().__init__(obj_dict)
         if obj_dict is None:
-            # Copy the attributes
+            if isinstance(src, (Node, Subgraph, Cluster)):
+                src = src.get_name()
+            if isinstance(dst, (Node, Subgraph, Cluster)):
+                dst = dst.get_name()
+            points = (src, dst)
+            self.obj_dict["points"] = points
             self.obj_dict["attributes"] = dict(attrs)
             self.obj_dict["type"] = "edge"
             self.obj_dict["parent_graph"] = None
             self.obj_dict["sequence"] = None
-        else:
-            self.obj_dict = obj_dict
 
     def __str__(self) -> str:
         return self.to_string()
@@ -964,12 +954,8 @@ class Graph(Common):
         simplify: bool = False,
         **attrs: Any,
     ) -> None:
-        if obj_dict is not None:
-            self.obj_dict = obj_dict
-
-        else:
-            self.obj_dict = {}
-
+        super().__init__(obj_dict)
+        if obj_dict is None:
             self.obj_dict["attributes"] = dict(attrs)
 
             if graph_type not in ["graph", "digraph"]:
@@ -1549,15 +1535,13 @@ class Subgraph(Graph):
         simplify: bool = False,
         **attrs: Any,
     ) -> None:
-        Graph.__init__(
-            self,
+        super().__init__(
             graph_name=graph_name,
             obj_dict=obj_dict,
             suppress_disconnected=suppress_disconnected,
             simplify=simplify,
             **attrs,
         )
-
         if obj_dict is None:
             self.obj_dict["type"] = "subgraph"
 
@@ -1602,15 +1586,13 @@ class Cluster(Graph):
         simplify: bool = False,
         **attrs: Any,
     ) -> None:
-        Graph.__init__(
-            self,
+        super().__init__(
             graph_name=graph_name,
             obj_dict=obj_dict,
             suppress_disconnected=suppress_disconnected,
             simplify=simplify,
             **attrs,
         )
-
         if obj_dict is None:
             self.obj_dict["type"] = "subgraph"
             self.obj_dict["name"] = quote_id_if_necessary(
@@ -1629,8 +1611,8 @@ class Dot(Graph):
     the base class 'Graph'.
     """
 
-    def __init__(self, *argsl: Any, **argsd: Any) -> None:
-        Graph.__init__(self, *argsl, **argsd)
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
         self.shape_files: List[str] = []
         self.formats = OUTPUT_FORMATS


### PR DESCRIPTION
Some cleanup of the main classes' setup and access methods:

### Init `obj_dict` in Common, and use `super()`
Give the Common class an `__init__()` that sets up the `obj_dict`, and call `super().__init__` from all of the subclasses. Makes the code in the subclass `__init__`s simpler.

### Simplify graph getters
    
* Calls like `get_node_defaults()` and `get_strict()` took an extra second argument that was never used for anything — eliminate it.
    
* The `get_*_defaults()` methods also wasted time checking whether the return value of `get_node()` is a list, but it's always a list.

### Standardize some naming
Don't call a variable `dict` (use `_dict` instead), and use `*args` and `**kwargs` in function signatures, not other weird names.