### PR TITLE
Rearrange/break up project extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,10 +67,7 @@ dev = [
   'mypy',
 ]
 tests = [
-  'chardet',
-  'parameterized',
-  'ruff',
-  'mypy',
+  'pydot[dev]',
   'tox',
   'pytest',
   'pytest-cov',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,11 +60,17 @@ Changelog = "https://github.com/pydot/pydot/blob/main/ChangeLog"
 "Bug Tracker" = "https://github.com/pydot/pydot/issues"
 
 [project.optional-dependencies]
+lint = [
+  'ruff',
+]
+types = [
+  'mypy',
+]
 dev = [
+  'pydot[lint]',
+  'pydot[types]',
   'chardet',
   'parameterized',
-  'ruff',
-  'mypy',
 ]
 tests = [
   'pydot[dev]',

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,7 +50,7 @@ commands =
     ruff check --fix .
 
 [testenv:mypy-check]
-extras = dev
+extras = types
 commands =
     mypy
 


### PR DESCRIPTION
This PR started as an effort to reduce repetition in our project extras, and kind of exploded from there — not always in especially useful ways. But it does achieve two practical benefits:

1. The aforementioned decrease in redundancy. Now, instead of the `tests` extra containing all of the same packages as the `dev` extra, it just contains `pydot[dev]`. (Because, turns out you can do that!)
2. A newly-added `types` extra, containing only `mypy`, is used in the `mypy-check` tox environment, avoiding the installation of all of the other packages in `pydot[dev]` that aren't needed for mypy checking.

Both the `dev` and `tests` extras contain the exact same set of packages before and after this PR, to avoid messing with anyone's habits/expectations. This PR just arranges to achieve that in a non-redundant manner.