### PR TITLE
backport: capitalized keywords in labels should be quoted 

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -345,7 +345,7 @@ def id_needs_quotes(s):
     # would use a reserved keyword as name. This function will return
     # false indicating that a keyword string, if provided as-is, won't
     # need quotes.
-    if s in dot_keywords:
+    if s.lower() in dot_keywords:
         return False
 
     any_result = any_needs_quotes(s)
@@ -398,7 +398,7 @@ def quote_attr_if_necessary(s):
     if not isinstance(s, str):
         return s
 
-    if s in dot_keywords:
+    if s.lower() in dot_keywords:
         return make_quoted(s)
 
     any_result = any_needs_quotes(s)

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -312,6 +312,13 @@ class TestGraphAPI(PydotTestCase):
             self.graph_directed.get_nodes()[0].to_string(), "node [shape=box];"
         )
 
+    def test_keyword_node_id_in_label(self):
+        self.graph_directed.add_node(pydot.Node("Node", label="Node"))
+        self.assertEqual(
+            self.graph_directed.get_nodes()[0].to_string(),
+            'Node [label="Node"];',
+        )
+
     def test_comma_separated_attribute_values_to_string(self):
         self._reset_graphs()
         self.graph_directed.add_node(


### PR DESCRIPTION
Backports #449 to v3