### PR TITLE
Update dot_parser.HTML and add tests

### DIFF
--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -30,6 +30,7 @@ from pyparsing import (
     Token,
     Word,
     cStyleComment,
+    lineno,
     nums,
     pyparsing_unicode,
     restOfLine,
@@ -75,6 +76,37 @@ class DefaultStatement(P_AttrList):
     def __repr__(self) -> str:
         name = self.__class__.__name__
         return f"{name}({self.default_type}, {self.attrs!r})"
+
+
+class HTML(Token):
+    """Parsing for HTML-like strings."""
+
+    def __init__(self) -> None:
+        super().__init__()  # type: ignore
+
+    def parseImpl(
+        self, instring: str, loc: int, do_actions: bool = True
+    ) -> T.Tuple[int, str]:
+        open_loc = loc
+        if not (loc < len(instring) and instring[loc] == "<"):
+            raise ParseException(instring, loc, "expected <", self)
+        num_open = 1
+        loc += 1
+        while loc < len(instring):
+            if instring[loc] == "<":
+                num_open += 1
+            elif instring[loc] == ">":
+                num_open -= 1
+            loc += 1
+            if num_open == 0:
+                return loc, instring[open_loc:loc]
+        raise ParseException(
+            instring,
+            loc,
+            "HTML: expected '>' to match '<' "
+            + f"on line {lineno(open_loc, instring)}",
+            self,
+        )
 
 
 def push_top_graph_stmt(
@@ -381,35 +413,6 @@ def push_node_stmt(s: str, loc: int, toks: ParseResults) -> "pydot.core.Node":
 
     n = pydot.Node(str(node_name), **attrs)
     return n
-
-
-class HTML(Token):
-    def __init__(self) -> None:
-        super().__init__()  # type: ignore
-
-    def parseImpl(
-        self, instring: str, loc: int, do_actions: bool = True
-    ) -> T.Tuple[int, str]:
-        open_loc = loc
-        if not (loc < len(instring) and instring[loc] == "<"):
-            raise ParseException(instring, loc, "expected <", self)
-        num_open = 1
-        loc += 1
-        while loc < len(instring):
-            if instring[loc] == "<":
-                num_open += 1
-            elif instring[loc] == ">":
-                num_open -= 1
-            loc += 1
-            if num_open == 0:
-                return loc, instring[open_loc:loc]
-        raise ParseException(
-            instring,
-            loc,
-            "expected a > to match <, in the HTML string"
-            + "starting at {lineno(open_loc, instring)}",
-            self,
-        )
 
 
 graphparser = None

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2025 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit testing of individual dot_parser classes."""
+
+import pyparsing as pp
+import pytest
+
+from pydot.dot_parser import HTML
+
+
+def test_HTML_valid() -> None:
+    """Test successful HTML parses."""
+    parsed = HTML().parse_string("<<b>Bold Text</b>>")
+    assert isinstance(parsed, pp.ParseResults)
+    assert list(parsed) == ["<<b>Bold Text</b>>"]
+
+    parsed2 = HTML().parse_string("<Label #1>")
+    assert isinstance(parsed2, pp.ParseResults)
+    assert list(parsed2) == ["<Label #1>"]
+
+
+def test_HTML_invalid() -> None:
+    """Test HTML parsing failure."""
+    with pytest.raises(pp.ParseException) as exc:
+        HTML().parse_string("<<b>Unbalanced tags</b>")
+    assert "HTML: expected '>' to match '<' on line 1" in str(exc.value)


### PR DESCRIPTION
I'm an idiot.

And, apologies to @davidweichiang for my being an idiot.

If I'd _not_ been an idiot, I'd have realized that **of course** we can test the `HTML` parsing class, including its exception — just, not within the context of the complete `graphparser`. We test it just like we'd unit test any other class: _In isolation._

If I'd realized that, and written (or asked for) some unit tests on the class, we'd have caught that:

1. The `pyparsing.lineno` import went missing. (Ruff removed it.)
2. ...because the exception message for the `HTML` class was missing the `f` on its (non-)f-string, which means the `{lineno()}` call wasn't being interpreted as Python code.
3. And it was also missing a space between two words (where it was split into two strings).

So, this PR fixes those things, and adds a new test file `test/test_parser.py`, which currently contains only some pytest tests for `pydot.dot_parser.HTML` — both successful and failed parses. (The failed parse is where we can actually see its exception in use.)

It also moves the class up to the top of the `dot_parser.py` file with the other classes, gives it a docstring, and shortens the exception message slightly (as it proved a bit unwieldy, in practice).