### PR TITLE
dot_parser: Define parser elements in a class

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -61,5 +61,5 @@ python =
     3.12 = py312
     3.11 = py311
     3.10 = py310
-    3.9 = py39
-    3.8 = mypy-check, py38
+    3.9 = mypy-check, py39
+    3.8 = py38

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -15,7 +15,6 @@ import warnings
 from typing import Any, List, Optional, Sequence, Set, Tuple, Type, Union, cast
 
 import pydot
-import pydot.dot_parser
 from pydot._vendor import tempfile
 from pydot.classes import AttributeDict, FrozenDict
 
@@ -401,6 +400,8 @@ def graph_from_dot_data(s: str) -> Optional[List["Dot"]]:
     @return: Graphs that result from parsing.
     @rtype: `list` of `pydot.Dot`
     """
+    import pydot.dot_parser
+
     return pydot.dot_parser.parse_dot_data(s)
 
 

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -544,3 +544,7 @@ def parse_dot_data(s: str) -> T.Optional[T.List[pydot.core.Dot]]:
         print(" " * (err.column - 1) + "^")
         print(err)
         return None
+
+
+# Backwards compatibility
+graphparser: ParserElement = GraphParser.parser

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -82,7 +82,7 @@ class HTML(Token):
     """Parsing for HTML-like strings."""
 
     def __init__(self) -> None:
-        super().__init__()  # type: ignore
+        super().__init__()
 
     def parseImpl(
         self, instring: str, loc: int, do_actions: bool = True

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -280,17 +280,13 @@ def add_elements(
             raise ValueError(f"Unknown element statement: {element}")
 
 
-def push_graph_stmt(
-    s: str, loc: int, toks: ParseResults
-) -> pydot.core.Subgraph:
+def push_graph_stmt(toks: ParseResults) -> pydot.core.Subgraph:
     g = pydot.core.Subgraph("")
     add_elements(g, toks)
     return g
 
 
-def push_subgraph_stmt(
-    s: str, loc: int, toks: ParseResults
-) -> pydot.core.Subgraph:
+def push_subgraph_stmt(toks: ParseResults) -> pydot.core.Subgraph:
     g = pydot.core.Subgraph("")
     for e in toks:
         if len(e) == 3:
@@ -306,9 +302,7 @@ def push_subgraph_stmt(
     return g
 
 
-def push_default_stmt(
-    s: str, loc: int, toks: ParseResults
-) -> DefaultStatement:
+def push_default_stmt(toks: ParseResults) -> DefaultStatement:
     # The pydot class instances should be marked as
     # default statements to be inherited by actual
     # graphs, nodes and edges.
@@ -325,7 +319,7 @@ def push_default_stmt(
         raise ValueError(f"Unknown default statement: {toks}")
 
 
-def push_attr_list(s: str, loc: int, toks: ParseResults) -> P_AttrList:
+def push_attr_list(toks: ParseResults) -> P_AttrList:
     p = P_AttrList(toks)
     return p
 
@@ -348,9 +342,7 @@ def do_node_ports(node: T.Any) -> str:
     return node_port
 
 
-def push_edge_stmt(
-    s: str, loc: int, toks: ParseResults
-) -> T.List[pydot.core.Edge]:
+def push_edge_stmt(toks: ParseResults) -> T.List[pydot.core.Edge]:
     tok_attrs = [a for a in toks if isinstance(a, P_AttrList)]
     attrs = {}
     for a in tok_attrs:
@@ -406,7 +398,7 @@ def push_edge_stmt(
     return e
 
 
-def push_node_stmt(s: str, loc: int, toks: ParseResults) -> pydot.core.Node:
+def push_node_stmt(toks: ParseResults) -> pydot.core.Node:
     if len(toks) == 2:
         attrs = toks[1].attrs
     else:


### PR DESCRIPTION
This PR is centered around one major, should-be-api/user-transparent change to the `dot_parser` code which will change everything for us:

The final `ParserElement` that we use for parsing, **as well as all of the component parsing fragments used to build it**, are now defined in the top level of a class definition named `GraphParser`.

The class is not meant to be instantiated (though it can be), and it consists only of class-member variables, all of which are the `ParserElement` components of our parser definition. The final element, `GraphParser.parser`, is what used to be stored in the global `graphparser` symbol. (Which is preserved for compatibility, even though our own code won't use it anymore.)

Having access to the parser components is a necessary step towards being able to finally debug, test, and modify the parser. With the new class, I can do things like this:

```python3
>>> from pydot.dot_parser import GraphParser

>>> # If I want to test our parsing of attribute lists...
>>> GraphParser.attr_list.parse_string(
... '''[color="red", style="dashed, filled", width=12.5]''')
ParseResults([P_AttrList({'color': '"red"', 'style': '"dashed, filled"', 'width': '12.5'})], {})

>>> # Or edge statements...
>>> elist = GraphParser.edge_stmt.parse_string(
... '''a:5:sw -- b:4:ne [color=blue]''')
>>> print(elist[0].to_string())
a:5:sw -- b:4:ne [color=blue];

>>> # Or if I want to start trying to figure out why our
>>> # parsing of complex edges is totally broken...
>>> g = GraphParser.parser.parse_string(
... '''graph G { a -- { b; c; } -- d; }''')
>>> print(g[0].to_string(indent=2))
graph G {
  a -- subgraph {
    b;
    c;
  };
}

>>> # Well, that's clearly not right. What is the edge
>>> # parser doing?
>>> for e in GraphParser.edge_stmt.parse_string(
... '''a -- b -- c [color=blue]'''):
...     print(e.to_string())
... 
a -- b [color=blue];
b -- c [color=blue];

>>> # So far so good, but...
>>> GraphParser.edge_stmt.parse_string(
... '''a:5:sw -- { n; m } -- b:4:ne [color=blue]''')
ParseResults([<pydot.core.Edge object at 0x7fcc1089e5d0>], {})
>>> elist = GraphParser.edge_stmt.parse_string(
... '''a:5:sw -- { n; m } -- b:4:ne [color=blue]''')
>>> elist[0].to_string()
'a:5:sw -- subgraph {\nn;\nm;\n} [color=blue];'
```

So now I at least have a starting point to look into the code. It's also possible to disable parse actions (just call `.set_parse_action()` with no arguments on any of the `ParserElement` objects that have one, to clear it out) in order to get a look at the values being sent _into_ the parse action.

And we can write unit tests for all of the parser pieces, now, instead of only testing it as a black box.

## Other changes made
- `dot_parser` now only imports, and only refers to, `pydot.core.*` classes; the compatibility exports at the `pydot` level are never used. That makes the dependency graph more manageable.
- By the same token, the top-level import of `pydot.dot_parser` is gone from `core.py`. It's now only imported on demand, when `graph_from_dot_data()` needs it.
- All type hints in `dot_parser` are now real references to imported classes, it no longer uses string annotations.
- Unused `s` and `loc` arguments are removed from parse action functions that don't use them (something PyParsing has supported for a long while, now).
- <s>The no-op `__init__` is removed from the `HTML` class, since its unused type-ignore comment was annoying MyPy and it served no purpose anyway.</s> OK, correction, `HTML.__init__()` can't be removed, just its `# type: ignore` comment.

## Notes
This will cause huge conflicts with my other open PR, but it's worth the disruption. I'll do the work of resolving those once they occur.