### PR TITLE
Fix complex edge parsing

### DIFF
--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -18,6 +18,7 @@ import typing as T
 from pyparsing import (
     CaselessLiteral,
     Combine,
+    DelimitedList,
     Forward,
     Group,
     Literal,
@@ -351,50 +352,26 @@ def push_edge_stmt(toks: ParseResults) -> T.List[pydot.core.Edge]:
 
     e = []
 
-    if isinstance(toks[0][0], pydot.core.Graph):
-        n_prev = FrozenDict(toks[0][0].obj_dict)
-    else:
-        n_prev = toks[0][0] + do_node_ports(toks[0])
+    def make_endpoint(
+        ep: T.Union[pydot.core.Common, T.List[T.Any], str],
+    ) -> T.Union[FrozenDict, str]:
+        if isinstance(ep, (list, tuple)) and len(ep) == 1:
+            # This is a hack for the Group()ed edge_point definition
+            ep = ep[0]
+        if isinstance(ep, pydot.core.Subgraph):
+            ep.obj_dict["show_keyword"] = False
+            return FrozenDict(ep.obj_dict)
+        if isinstance(ep, (list, tuple)):
+            return str(ep[0]) + do_node_ports(ep)
+        return str(ep)
 
-    if isinstance(toks[2][0], ParseResults):
-        n_next_list = [[n.get_name()] for n in toks[2][0]]
-        for n_next in list(n_next_list):
-            n_next_port = do_node_ports(n_next)
-            e.append(pydot.core.Edge(n_prev, n_next[0] + n_next_port, **attrs))
+    endpoints = [t for t in toks.as_list() if not isinstance(t, P_AttrList)]
 
-    elif isinstance(toks[2][0], pydot.core.Graph):
-        e.append(
-            pydot.core.Edge(n_prev, FrozenDict(toks[2][0].obj_dict), **attrs)
-        )
-
-    elif isinstance(toks[2][0], pydot.core.Node):
-        node = toks[2][0]
-
-        name_port: str
-        if node.get_port() is not None:
-            name_port = node.get_name() + ":" + node.get_port()  # type: ignore
-        else:
-            name_port = node.get_name()
-
-        e.append(pydot.core.Edge(n_prev, name_port, **attrs))
-
-    # if the target of this edge is the name of a node
-    elif isinstance(toks[2][0], str):
-        for n_next in list(tuple(toks)[2::2]):
-            if isinstance(n_next, P_AttrList) or not isinstance(
-                n_next[0], str
-            ):
-                continue
-
-            n_next_port = do_node_ports(n_next)
-            e.append(pydot.core.Edge(n_prev, n_next[0] + n_next_port, **attrs))
-
-            n_prev = n_next[0] + n_next_port  # type: ignore
-    else:
-        raise Exception(
-            f"Edge target {toks[2][0]} with type {type(toks[2][0])}"
-            " unsupported."
-        )
+    n_prev = make_endpoint(endpoints[0])
+    for endpoint in endpoints[1:]:
+        n_next = make_endpoint(endpoint)
+        e.append(pydot.core.Edge(n_prev, n_next, **attrs))
+        n_prev = n_next
 
     return e
 
@@ -466,8 +443,6 @@ class GraphParser:
 
     attr_stmt = Group(graph_ | node_ | edge_) + attr_list
 
-    edgeop = Literal("--") | Literal("->")
-
     stmt_list = Forward()
     graph_stmt = Group(
         lbrace.suppress()
@@ -476,14 +451,13 @@ class GraphParser:
         + Optional(semi.suppress())
     )
 
-    edge_point = Forward()
-
-    edgeRHS = OneOrMore(edgeop + edge_point)
-    edge_stmt = edge_point + edgeRHS + Optional(attr_list)
-
     subgraph = Group(subgraph_ + Optional(ID) + graph_stmt)
 
-    edge_point <<= Group(subgraph | graph_stmt | node_id)
+    edgeop = Literal("--") | Literal("->")
+    edge_point = Group(subgraph | graph_stmt | node_id)
+    edge_stmt = DelimitedList(edge_point, delim=edgeop, min=2) + Optional(
+        attr_list
+    )
 
     node_stmt = node_id + Optional(attr_list) + Optional(semi.suppress())
 

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -284,6 +284,7 @@ def add_elements(
 
 def push_graph_stmt(toks: ParseResults) -> pydot.core.Subgraph:
     g = pydot.core.Subgraph("")
+    g.obj_dict["show_keyword"] = False
     add_elements(g, toks)
     return g
 
@@ -359,7 +360,6 @@ def push_edge_stmt(toks: ParseResults) -> T.List[pydot.core.Edge]:
             # This is a hack for the Group()ed edge_point definition
             ep = ep[0]
         if isinstance(ep, pydot.core.Subgraph):
-            ep.obj_dict["show_keyword"] = False
             return FrozenDict(ep.obj_dict)
         if isinstance(ep, (list, tuple)):
             return str(ep[0]) + do_node_ports(ep)

--- a/test/graphs/complex_edges.dot
+++ b/test/graphs/complex_edges.dot
@@ -1,0 +1,5 @@
+graph G {
+  a -- {b c} -- d [penwidth=5];
+  {e; f;} -- {x [color=blue]; y [color=green]; } [color=red];
+}
+


### PR DESCRIPTION
This PR makes minimal changes to the parser to fix the parsing of what I'm calling "complex" edges, meaning ones that contain subgraph endpoints. The parser is now able to correctly interpret a graph with edges like these:

```dot
graph G {
  a -- {b; c;} -- d -- {e; f; };
  {x [color=blue]; y [color=red]; z; } -- {m n o p} [penwidth=5];
}
```

Specifically, after parsing that becomes:

```dot
graph G {
  a -- {
    b;
    c;
  };
  {
    b;
    c;
  } -- d;
  d -- {
    e;
    f;
  };
  {
    x [color=blue];
    y [color=red];
    z;
  } -- {
    m;
    n;
    o;
    p;
  } [penwidth=5];
}
```
(Note to self: Fix the `inline` mode in `Subgraph.to_string()`...)

And renders to SVG as:

![g](https://github.com/user-attachments/assets/8a26ac98-f017-44ec-81cf-e7f06b1bcaa8)


A new test file `test/graphs/complex_edges.dot` is added to exercise the feature and ensure that our output is the same as `dot`'s.

### Other changes

* A preceding setup commit eliminates all of the `.setName()` calls on `ParserElement`s in the `GraphParser` definition, by instead calling the `autoname_elements()` function from PyParsing when finished. This is a feature that's been available for some time, that sets the name of every local `ParserElement` to the name of the variable it's stored in. Which is exactly what we were doing anyway.

* The eventual definition of `Forward()` `ParserElement`s (which is now only `stmt_list`, I managed to eliminate the unnecessary forward-declaration of `edge_point`) now uses `<<=` instead of `<<`, another PyParsing adjustment since `<<` isn't meant to assign values to things. Abusing it to do so made static analysis messier.