### PR TITLE
Type edge endpoints, tighten getter typing, and improve suppress_disconnected and strict modes (with tests)

### DIFF
--- a/src/pydot/classes.py
+++ b/src/pydot/classes.py
@@ -5,10 +5,7 @@
 """Frozen dictionaries."""
 
 import copy
-from typing import Any, Dict, Tuple
-
-# Backwards-compatible typing alias
-AttributeDict = Dict[str, Any]
+from typing import Any, Dict, Tuple, Union
 
 
 class FrozenDict(dict):  # type: ignore
@@ -85,3 +82,8 @@ class FrozenDict(dict):  # type: ignore
     def __repr__(self) -> str:
         dict_repr = dict.__repr__(self)
         return f"FrozenDict({dict_repr})"
+
+
+# Backwards-compatible typing alias
+AttributeDict = Dict[str, Any]
+EdgeEndpoint = Union[str, int, float, FrozenDict]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -41,6 +41,8 @@ def objdict() -> T.Dict[str, T.Any]:
                 }
             ],
         },
+        "edges": {},
+        "subgraphs": {},
     }
 
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -8,6 +8,7 @@ import os
 import pickle
 import string
 import textwrap
+import typing as T
 
 import pytest
 
@@ -423,6 +424,29 @@ def test_dot_args() -> None:
         outfile = os.path.join(tmp_dir, "test.svg")
         g.write_svg(outfile, prog=["twopi", "-Goverlap=scale"])
         assert os.path.exists(outfile)
+
+
+def test_suppress_disconnected() -> None:
+    g1 = pydot.graph_from_dot_data(
+        "graph G { a; b; a -- b; c; d; a -- c; b -- c; e; }"
+    )
+    assert g1 is not None
+    gr1 = g1[0]
+    g2 = pydot.graph_from_dot_data(
+        "graph G { a; b; a -- b; c; a -- c; b -- c; }"
+    )
+    assert g2 is not None
+    gr2 = g2[0]
+    gr1.set_suppress_disconnected(True)
+    assert gr1.to_string() == gr2.to_string()
+
+
+def test_strict(objdict: T.Dict[str, T.Any]) -> None:
+    g = pydot.Dot(obj_dict=objdict)
+    g.set_parent_graph(g)
+    g.set_strict(True)
+    s = g.to_string()
+    assert s == "strict graph G {\n3;\n16;\n}\n"
 
 
 def test_edge_equality_basics_3_same_points_not_not_equal() -> None:


### PR DESCRIPTION
### Add two new type aliases related to `Edge` objects

- `EdgeDefinition` represents the input type for the `src` and `dst` arguments of `Edge.__init__`. It can be a `Node`, `Subgraph`, `Cluster`, `FrozenDict`, or `int`, `float`, or `str`
- `EdgeEndpoint` represents the _output_ type, which can be any of `FrozenDict`, `int`, `float`, or `str`. Any Pydot classes passed in have been dereferenced to their `.get_name()` value.

### Tighten up typing of setters, getters

By making methods like `get_strict()` and `get_simplify()` no longer return `Optional` values, but forcing a `bool` result, we can use those methods in `.to_string()` and other places without running afoul of the type system.

### Improve & test `strict`, `suppress_disconnected`

When suppressing disconnected nodes, we only care if a node is on _any_ endpoint of an edge — we don't care if it's the `src` or `dst` endpoint. So, instead of keeping separate `edge_src_set` and `edge_dst_set` to compare against, glom them all into a single `edge_ep_set` that the node can be checked against.

Add new `test_api` test functions for both `strict` and `suppress_disconnected`