### PR TITLE
Upate pyparsing version for DelimitedList support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,6 @@ jobs:
           - "3.11"
           - "3.10"
           - "3.9"
-          - "3.8"
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -74,7 +73,7 @@ jobs:
         if: runner.os == 'macos'
         run: brew install graphviz
       - name: "Install Python dependencies"
-        run: python -m pip install pip==24.0.0 setuptools==68.0.0 wheel==0.42.0 tox==4.8.0 tox-gh==1.3.1
+        run: python -m pip install pip==24.0.0 setuptools==75.3.2 wheel==0.42.0 tox==4.8.0 tox-gh==1.3.1
       - name: "Setup tests"
         run: tox -vv --notest
       - name: "Run tests"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To see what Graphviz is capable of, check the [Graphviz Gallery](https://graphvi
 
 ## Dependencies
 
+- Python: The latest version of pydot supports Python 3.9+. It may work with Python 3.6-3.8, but we can't guarantee full support. If you're using one of these older versions, feel free to experiment, but we won't be able to address issues specific to them. Older versions of pydot are also an option.
 - [`pyparsing`][pyparsing]: used only for *loading* DOT files, installed automatically during `pydot` installation.
 - GraphViz: used to render graphs in a variety of formats, including PNG, SVG, PDF, and more.
   Should be installed separately, using your system's [package manager][pkg], something similar (e.g., [MacPorts][mac]), or from [its source][src].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools >= 75.3.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license-files = [
 ]
 requires-python = ">= 3.8"
 dependencies = [
-  'pyparsing>=3.0.9'
+  'pyparsing>=3.1.0'
 ]
 authors = [
   {name = "Ero Carrera", email = "ero.carrera@gmail.com"},

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ env_list =
     py311
     py310
     py39
-    py38
     ruff-check
     mypy-check
 
@@ -62,4 +61,3 @@ python =
     3.11 = py311
     3.10 = py310
     3.9 = mypy-check, py39
-    3.8 = py38


### PR DESCRIPTION
This ensures that `DelimitedList` imported here https://github.com/pydot/pydot/blob/c37e44bfdadb31e91b4e3a96e0c832af65d60c12/src/pydot/dot_parser.py#L21 is available in `pyparsing`, as this was only introduced in 3.1.0 (https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_1.html#id4).

See issue https://github.com/pydot/pydot/issues/474