### PR TITLE
Update pyparsing dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ license-files = [
 ]
 requires-python = ">= 3.8"
 dependencies = [
-  'pyparsing>=3.0.9'
+  'pyparsing>=3.1.0'
 ]
 authors = [
   {name = "Ero Carrera", email = "ero.carrera@gmail.com"},


### PR DESCRIPTION
This ensures that `DelimitedList` imported here https://github.com/pydot/pydot/blob/c37e44bfdadb31e91b4e3a96e0c832af65d60c12/src/pydot/dot_parser.py#L21 is available in `pyparsing`, as this was only introduced in 3.1.0 (https://pyparsing-docs.readthedocs.io/en/latest/whats_new_in_3_1.html#id4).

See issue https://github.com/pydot/pydot/issues/474