### PR TITLE
Parser: Support backslash continuation in quoted IDs

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -569,7 +569,7 @@ class Common:
         self.obj_dict["parent_graph"] = parent_graph
 
     def get_parent_graph(self) -> Graph | None:
-        return self.obj_dict.get("parent_graph", None)  # type: ignore
+        return self.obj_dict.get("parent_graph", None)
 
     def get_top_graph_type(self, default: str = "graph") -> str:
         """Find the topmost parent graph type for the current object."""

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -175,8 +175,7 @@ def push_dbl_quoted(toks: ParseResults) -> str:
     assert "dbl_quoted" in toks and isinstance(toks.dbl_quoted, str)
     s = toks.dbl_quoted
     # Remove backslash line-continuations
-    if "\\\n" in s or "\\\r\n" in s:
-        s = s.replace("\\\r\n", "").replace("\\\n", "")
+    s = s.replace("\\\r\n", "").replace("\\\n", "")
     return s
 
 

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -171,6 +171,15 @@ def expand_attr_lists(attr_l: Any) -> dict[str, Any]:
     return attrs
 
 
+def push_dbl_quoted(toks: ParseResults) -> str:
+    assert "dbl_quoted" in toks and isinstance(toks.dbl_quoted, str)
+    s = toks.dbl_quoted
+    # Remove backslash line-continuations
+    if "\\\n" in s or "\\\r\n" in s:
+        s = s.replace("\\\r\n", "").replace("\\\n", "")
+    return s
+
+
 def push_graph_stmt(toks: ParseResults) -> pydot.core.Subgraph:
     g = pydot.core.Subgraph("")
     g.obj_dict["show_keyword"] = False
@@ -254,10 +263,14 @@ class GraphParser:
     )
 
     double_quoted_string = QuotedString(
-        '"', multiline=True, unquoteResults=False, escChar="\\"
+        '"', multiline=True, unquote_results=False, esc_char="\\"
     )
 
-    ID = identifier | HTML() | double_quoted_string
+    ID = (
+        identifier
+        | HTML()
+        | double_quoted_string("dbl_quoted").set_parse_action(push_dbl_quoted)
+    )
 
     float_number = Combine(Optional(minus) + OneOrMore(Word(nums + ".")))
 

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -175,7 +175,8 @@ def push_dbl_quoted(toks: ParseResults) -> str:
     assert "dbl_quoted" in toks and isinstance(toks.dbl_quoted, str)
     s = toks.dbl_quoted
     # Remove backslash line-continuations
-    s = s.replace("\\\r\n", "").replace("\\\n", "")
+    if "\\" in s:
+        s = s.replace("\\\r\n", "").replace("\\\n", "")
     return s
 
 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -97,3 +97,23 @@ def test_strict_graph_parsing() -> None:
     assert len(res2) == 2
     assert not res2[0].get_strict()
     assert res2[1].get_strict()
+
+
+def test_backslash_continuations() -> None:
+    src = textwrap.dedent(r"""
+        graph G {
+            "my very long node \
+        name" [color=red];
+            "my indented and wrapped \
+            node name" [shape=square];
+            "my node name containing \ backslash";
+        }""")
+    res = dot_parser.parse_dot_data(src)
+    assert isinstance(res, list)
+    assert len(res) == 1
+    graph = res[0]
+    nodes = graph.get_nodes()
+    assert len(nodes) == 3
+    assert nodes[0].get_name() == '"my very long node name"'
+    assert nodes[1].get_name() == '"my indented and wrapped     node name"'
+    assert nodes[2].get_name() == '"my node name containing \\ backslash"'


### PR DESCRIPTION
A new parse action `push_dbl_quoted` will run whenever a double-quoted string is parsed, finding any line-breaks (`\r\n` or `\n`) immediately preceded by a backslash (`\`) and removing both (joining the two lines together).

Other backslashes will not be modified, so for example this graph:

```dot
graph G {
    "my very long node \
name" [color=red];
    "my node name containing \ backslash";
}
```

...will have two nodes, one named `"my very long node name"` and one named `"my node name containing \\ backslash"`.

A new test is included to verify the results, which are consistent with `dot`'s own parsing (which preserves spaces when wrapping, so for instance this node will be named `"my very long node     name"`):

```dot
graph G {
    "my very long node \
    name";
}
```

Note that this only modifies the parser, and does _not_ address the processing of IDs with embedded backslashes when created via the Pydot API. It also does not add unquoting of parsed strings, which is still intended to be part of #420 and will require a major-version bump.

Fixes #483

