### PR TITLE
Tighten up our API with keyword-only arguments

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -623,7 +623,7 @@ class Common:
         return int(seq)
 
     @staticmethod
-    def get_indent(indent: Any, indent_level: int) -> str:
+    def get_indent(indent: str | int | float, indent_level: int) -> str:
         if isinstance(indent, (int, float)):
             indent_str = " " * int(indent)
         else:
@@ -724,7 +724,9 @@ class Node(Common):
 
         self.obj_dict["attributes"]["style"] = ",".join(styles)
 
-    def to_string(self, indent: Any = "", indent_level: int = 1) -> str:
+    def to_string(
+        self, indent: str | int | float = "", indent_level: int = 1
+    ) -> str:
         """Return string representation of node in DOT language."""
         indent_str = self.get_indent(indent, indent_level)
 
@@ -896,7 +898,9 @@ class Edge(Common):
 
         return quote_id_if_necessary(node_ref)
 
-    def to_string(self, indent: Any = "", indent_level: int = 1) -> str:
+    def to_string(
+        self, indent: str | int | float = "", indent_level: int = 1
+    ) -> str:
         """Return string representation of edge in DOT language."""
         src = self.parse_node_ref(self.get_source())
         dst = self.parse_node_ref(self.get_destination())
@@ -1406,7 +1410,10 @@ class Graph(Common):
                 Graph(obj_dict=obj).set_parent_graph(parent_graph)
 
     def to_string(
-        self, indent: Any = "", indent_level: int = 0, inline: bool = False
+        self,
+        indent: str | int | float = "",
+        indent_level: int = 0,
+        inline: bool = False,
     ) -> str:
         """Return string representation of graph in DOT language.
 

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -346,7 +346,7 @@ def id_needs_quotes(s: str) -> bool:
 
 
 def quote_id_if_necessary(
-    s: str, unquoted_keywords: Sequence[str] | None = None
+    s: str, *, unquoted_keywords: Sequence[str] | None = None
 ) -> str:
     """Enclose identifier in quotes, if needed."""
     unquoted = [
@@ -673,6 +673,7 @@ class Node(Common):
     def __init__(
         self,
         name: str = "",
+        *,
         obj_dict: AttributeDict | None = None,
         **attrs: Any,
     ) -> None:
@@ -725,7 +726,7 @@ class Node(Common):
         self.obj_dict["attributes"]["style"] = ",".join(styles)
 
     def to_string(
-        self, indent: str | int | float = "", indent_level: int = 1
+        self, *, indent: str | int | float = "", indent_level: int = 1
     ) -> str:
         """Return string representation of node in DOT language."""
         indent_str = self.get_indent(indent, indent_level)
@@ -780,6 +781,7 @@ class Edge(Common):
         self,
         src: EdgeDefinition | Sequence[EdgeDefinition] = "",
         dst: EdgeDefinition = "",
+        *,
         obj_dict: AttributeDict | None = None,
         **attrs: Any,
     ) -> None:
@@ -899,7 +901,7 @@ class Edge(Common):
         return quote_id_if_necessary(node_ref)
 
     def to_string(
-        self, indent: str | int | float = "", indent_level: int = 1
+        self, *, indent: str | int | float = "", indent_level: int = 1
     ) -> str:
         """Return string representation of edge in DOT language."""
         src = self.parse_node_ref(self.get_source())
@@ -977,11 +979,12 @@ class Graph(Common):
     def __init__(
         self,
         graph_name: str = "G",
-        obj_dict: AttributeDict | None = None,
         graph_type: str = "digraph",
+        *,
         strict: bool = False,
         suppress_disconnected: bool = False,
         simplify: bool = False,
+        obj_dict: AttributeDict | None = None,
         **attrs: Any,
     ) -> None:
         super().__init__(obj_dict)
@@ -1138,7 +1141,7 @@ class Graph(Common):
 
         graph_node.set_sequence(self.get_next_sequence_number())
 
-    def del_node(self, name: str | Node, index: int | None = None) -> bool:
+    def del_node(self, name: str | Node, *, index: int | None = None) -> bool:
         """Delete a node from the graph.
 
         Given a node's name all node(s) with that same name
@@ -1232,7 +1235,7 @@ class Graph(Common):
         graph_edge.set_parent_graph(self.get_parent_graph())
 
     def del_edge(
-        self, src_or_list: Any, dst: Any = None, index: int | None = None
+        self, src_or_list: Any, dst: Any = None, *, index: int | None = None
     ) -> bool:
         """Delete an edge from the graph.
 
@@ -1411,6 +1414,7 @@ class Graph(Common):
 
     def to_string(
         self,
+        *,
         indent: str | int | float = "",
         indent_level: int = 0,
         inline: bool = False,
@@ -1559,9 +1563,10 @@ class Subgraph(Graph):
     def __init__(
         self,
         graph_name: str = "",
-        obj_dict: AttributeDict | None = None,
-        suppress_disconnected: bool = False,
+        *,
         simplify: bool = False,
+        suppress_disconnected: bool = False,
+        obj_dict: AttributeDict | None = None,
         **attrs: Any,
     ) -> None:
         super().__init__(
@@ -1610,9 +1615,10 @@ class Cluster(Graph):
     def __init__(
         self,
         graph_name: str = "subG",
-        obj_dict: AttributeDict | None = None,
+        *,
         suppress_disconnected: bool = False,
         simplify: bool = False,
+        obj_dict: AttributeDict | None = None,
         **attrs: Any,
     ) -> None:
         super().__init__(
@@ -1699,8 +1705,9 @@ class Dot(Graph):
     def write(
         self,
         path: str | bytes,
-        prog: str | None = None,
+        *,
         format: str = "raw",
+        prog: str | None = None,
         encoding: str | None = None,
     ) -> bool:
         """Writes a graph to a file.
@@ -1734,15 +1741,16 @@ class Dot(Graph):
             with open(path, mode="w", encoding=encoding) as f:
                 f.write(s)
         else:
-            s = self.create(prog, format, encoding=encoding)
+            s = self.create(format, prog=prog, encoding=encoding)
             with open(path, mode="wb") as f:
                 f.write(s)  # type: ignore
         return True
 
     def create(
         self,
-        prog: list[str] | tuple[str] | str | None = None,
         format: str = "ps",
+        *,
+        prog: list[str] | tuple[str] | str | None = None,
         encoding: str | None = None,
     ) -> str:
         """Creates and returns a binary image for the graph.


### PR DESCRIPTION
To tighten up the way the API is used, add an `*` to the argument
list of appropriate methods, to signify that the arguments beyond
that point are keyword-only.

Specifically...

- in `to_string` methods, `indent` is keyword-only (as is the
  internal `indent_level`)

- in `del_` methods, the optional `index` is keyword-only

- `quote_id_if_necessary`'s `unquoted_keywords` is keyword-only

- in all constructors except `Common.__init__`, `obj_dict` is
  keyword-only, and moved to the end of the keyword argument list.
  (It's not kw-only in `Common`, because it's the ONLY argument and
  the other constructors call it as `super().__init__(obj_dict)`.)

- Constructor arguments like `strict`, `suppress_disconnected`, etc.
  for `Graph` types are keyword-only.

- `graph_type` is explicitly _not_ kw-only, meaning a graph
  could be constructed as `pydot.Graph("G", "digraph")` which seems
  perfectly fine.

- `Dot.create` used to be called internally by `Dot.write` as
  `Dot.create(prog, format, encoding=)` which didn't seem like a
  very comfortable API for outside users, so now the `create` method
  takes `format` as the only positional argument, and the call is
  changed to `Dot.create(format, prog=, encoding=)`

- `Dot.write` itself takes only the `path` as a positional argument,
  the rest are keyword-only. While it might be nice to allow something
  like `Dot.write('/some/path', 'pdf')`, since the format is the
  _first_ positional argument of `Dot.create()` that's potentially
  confusing. (Ideally maybe `Dot.write()` should be able to infer the
  format based on the filename.)

### Rationale

It used to be possible, at least in theory, to make calls like these:

```python
g = pydot.Dot("G", None, "digraph", True, False, True)

g.to_string(3)           # (indent=3)
g.to_string("    ")      # (indent="    ") 
g.del_edge("a", "b", 3)  # (index=3)

pydot.quote_id_if_necessary(some_id, ("node", "edge", "graph"))

d = pydot.Dot("", g.obj_dict)
d.write('/tmp/out.svg', "dot", "svg", "utf-8")
d.create("neato", "svg", "latin1")
```

...all of which seem inadvisable and best avoided.

We're pretty good about keyword args in our own code. (I only had to change _one_ call to conform with this, an ancient `create()` call in `Dot.write` that used a weird set of positional arguments.) But, still, better that it's enforced by the method definitions. So, create some enforcement.

With this change, it's made explicit that the correct way to make the calls above is:

```python
# (Either of these is fine)
g = pydot.Graph("G", "digraph", strict=True, simplify=True)
g = pydot.Graph("G", graph_type="digraph", strict=True, simplify=True)

g.to_string(indent=3)
g.to_string(indent="    ")
g.del_edge("a", "b", index=3)

pydot.quote_id_if_necessary(
    some_id, unquoted_keywords=("node", "edge", "graph")
)
d = pydot.Dot(obj_dict=g.obj_dict)
d.write('/tmp/out.svg', format="svg", prog="dot", encoding="utf-8")
d.create("svg", prog="neato", encoding="latin1")
```

### Other changes

A second commit tightens the type for `.to_string(indent)` from `Any` to `str | int | float`.