### PR TITLE
Make graph object classes subclassable

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -565,6 +565,18 @@ class Common:
     def __setstate__(self, state: AttributeDict) -> None:
         self.obj_dict = state
 
+    @staticmethod
+    def _wrap_node(obj_dict: AttributeDict) -> Node:
+        return Node(obj_dict=obj_dict)
+
+    @staticmethod
+    def _wrap_edge(obj_dict: AttributeDict) -> Edge:
+        return Edge(obj_dict=obj_dict)
+
+    @staticmethod
+    def _wrap_subgraph(obj_dict: AttributeDict) -> Subgraph:
+        return Subgraph(obj_dict=obj_dict)
+
     def set_parent_graph(self, parent_graph: Common | None) -> None:
         self.obj_dict["parent_graph"] = parent_graph
 
@@ -904,7 +916,7 @@ class Edge(Common):
         indent_str = self.get_indent(indent, indent_level)
 
         if isinstance(src, FrozenDict):
-            sgraph = Subgraph(obj_dict=src)
+            sgraph = self._wrap_subgraph(obj_dict=src)
             edge = [
                 sgraph.to_string(
                     indent=indent, indent_level=indent_level, inline=True
@@ -919,7 +931,7 @@ class Edge(Common):
             edge.append("--")
 
         if isinstance(dst, FrozenDict):
-            sgraph = Subgraph(obj_dict=dst)
+            sgraph = self._wrap_subgraph(obj_dict=dst)
             edge.append(
                 sgraph.to_string(
                     indent=indent, indent_level=indent_level, inline=True
@@ -1179,7 +1191,7 @@ class Graph(Common):
         if name in self.obj_dict["nodes"]:
             match.extend(
                 [
-                    Node(obj_dict=obj_dict)
+                    self._wrap_node(obj_dict=obj_dict)
                     for obj_dict in self.obj_dict["nodes"][name]
                 ]
             )
@@ -1200,7 +1212,9 @@ class Graph(Common):
 
         for node in self.obj_dict["nodes"]:
             obj_dict_list = self.obj_dict["nodes"][node]
-            node_objs.extend([Node(obj_dict=obj_d) for obj_d in obj_dict_list])
+            node_objs.extend(
+                [self._wrap_node(obj_dict=obj_d) for obj_d in obj_dict_list]
+            )
 
         return node_objs
 
@@ -1287,7 +1301,7 @@ class Graph(Common):
             edge_points = (src_or_list, dst)
             edge_points_reverse = (dst, src_or_list)
 
-        match = []
+        match: list[Edge] = []
 
         if edge_points in self.obj_dict["edges"] or (
             self.get_top_graph_type() == "graph"
@@ -1298,12 +1312,10 @@ class Graph(Common):
                 self.obj_dict["edges"].get(edge_points_reverse, None),
             )
 
-            for edge_obj_dict in edges_obj_dict:
-                match.append(
-                    Edge(
-                        edge_points[0], edge_points[1], obj_dict=edge_obj_dict
-                    )
-                )
+            match.extend(
+                self._wrap_edge(obj_dict=edge_obj_dict)
+                for edge_obj_dict in edges_obj_dict
+            )
 
         return match
 
@@ -1316,11 +1328,13 @@ class Graph(Common):
         This method returns the list of Edge instances
         composing the graph.
         """
-        edge_objs = []
+        edge_objs: list[Edge] = []
 
         for edge in self.obj_dict["edges"]:
             obj_dict_list = self.obj_dict["edges"][edge]
-            edge_objs.extend([Edge(obj_dict=obj_d) for obj_d in obj_dict_list])
+            edge_objs.extend(
+                [self._wrap_edge(obj_dict=obj_d) for obj_d in obj_dict_list]
+            )
 
         return edge_objs
 
@@ -1358,13 +1372,15 @@ class Graph(Common):
         Subgraph instances is returned.
         An empty list is returned otherwise.
         """
-        match = []
+        match: list[Subgraph] = []
 
         if name in self.obj_dict["subgraphs"]:
             sgraphs_obj_dict = self.obj_dict["subgraphs"].get(name)
 
-            for obj_dict_list in sgraphs_obj_dict:
-                match.append(Subgraph(obj_dict=obj_dict_list))
+            match.extend(
+                self._wrap_subgraph(obj_dict=obj_dict)
+                for obj_dict in sgraphs_obj_dict
+            )
 
         return match
 
@@ -1377,12 +1393,12 @@ class Graph(Common):
         This method returns the list of Subgraph instances
         in the graph.
         """
-        sgraph_objs = []
+        sgraph_objs: list[Subgraph] = []
 
         for sgraph in self.obj_dict["subgraphs"]:
             obj_dict_list = self.obj_dict["subgraphs"][sgraph]
             sgraph_objs.extend(
-                [Subgraph(obj_dict=obj_d) for obj_d in obj_dict_list]
+                self._wrap_subgraph(obj_dict=obj_d) for obj_d in obj_dict_list
             )
 
         return sgraph_objs
@@ -1476,7 +1492,7 @@ class Graph(Common):
 
         for idx, obj in obj_list:
             if obj["type"] == "node":
-                node = Node(obj_dict=obj)
+                node = self._wrap_node(obj_dict=obj)
 
                 if skip_disconnected and node.get_name() not in edge_ep_set:
                     continue
@@ -1487,7 +1503,7 @@ class Graph(Common):
                 graph.append(f"{node_str}\n")
 
             elif obj["type"] == "edge":
-                edge = Edge(obj_dict=obj)
+                edge = self._wrap_edge(obj_dict=obj)
 
                 if simplify and edge in edges_done:
                     continue
@@ -1499,7 +1515,7 @@ class Graph(Common):
                 edges_done.add(edge)
 
             else:
-                sgraph_str = Subgraph(obj_dict=obj).to_string(
+                sgraph_str = self._wrap_subgraph(obj_dict=obj).to_string(
                     indent=indent, indent_level=indent_level + 1
                 )
                 graph.append(f"{sgraph_str}")  # No newline, already present


### PR DESCRIPTION
Because of the way pydot handles object data (extracting the `obj_dict` from each graph member instance and storing _that_, then re-creating the corresponding class instance on demand), the graph element classes in `pydot.core` were effectively un-subclassable. Even if you were to create subclasses of `pydot.core.Node` and `pydot.core.Graph` and add your `MyNode()` objects to your `MyGraph` instance, a call to `mygraph_instance.get_node()` would return `pydot.core.Node` objects instead of the `MyNode` objects you passed in.

To overcome this limitation and make the graph elements subclassable, add `_wrap_{node,edge,subgraph}` static methods to `pydot.core.Common`, and call `self._wrap_foo()` when constructing `Foo` objects to return, instead of directly calling the `Foo(obj_dict=)` constructor.

This means that a subclass `MyGraph` can be made to work with `MyNode` objects instead of `pydot.core.Node` objects simply by overriding `MyGraph._wrap_node()`, and so on for the other types/classes.

No API implications, this is an internal change that has no effect in `pydot.core.*` classes itself, it only makes the writing of subclasses easier.

Proposed / sketched out in https://github.com/pydot/pydot/pull/492#issuecomment-3115074502