### PR TITLE
CI refresh/updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -40,8 +40,8 @@ jobs:
       matrix:
         system:
           - {os: ubuntu, can-fail: false}
-          - {os: windows, can-fail: true}
-          - {os: macos, can-fail: true}
+          - {os: windows, can-fail: false}
+          - {os: macos, can-fail: false}
         python-version:
           - "3.13"
           - "3.12"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,14 +9,18 @@ on:
     branches: ["main"]
     paths-ignore:
       - "**/README.md"
-      - "LICENSE"
+      - ".gitignore"
       - "ChangeLog"
+      - "LICENSES/**"
+      - "REUSE.toml"
   pull_request:
     branches: ["*"]
     paths-ignore:
       - "**/README.md"
-      - "LICENSE"
+      - ".gitignore"
       - "ChangeLog"
+      - "LICENSES/**"
+      - "REUSE.toml"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,7 @@ jobs:
         if: runner.os == 'macos'
         run: brew install graphviz
       - name: "Install Python dependencies"
-        run: python -m pip install pip==24.0.0 setuptools==75.3.2 wheel==0.42.0 tox==4.8.0 tox-gh==1.3.1
+        run: python -m pip install pip==25.2 setuptools==80.7.0 tox==4.30.2 tox-gh==1.5.0
       - name: "Setup tests"
         run: tox -vv --notest
       - name: "Run tests"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
           - {os: windows, can-fail: false}
           - {os: macos, can-fail: false}
         python-version:
+          - "3.14"
           - "3.13"
           - "3.12"
           - "3.11"
@@ -56,6 +57,7 @@ jobs:
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "${{ matrix.python-version }}"
+          allow-prereleases: true
           cache: "pip"
       - name: "Set up environment"
         shell: bash

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,16 +8,20 @@ on:
   push:
     branches: ["main"]
     paths-ignore: 
-      - "**/README.md" 
-      - "LICENSE" 
-      - "ChangeLog" 
+      - "**/README.md"
+      - ".gitignore"
+      - "ChangeLog"
+      - "LICENSES/**"
+      - "REUSE.toml"
   pull_request:
     # The branches below must be a subset of the branches above
     branches: ["main"]
     paths-ignore: 
-      - "**/README.md" 
-      - "LICENSE" 
-      - "ChangeLog" 
+      - "**/README.md"
+      - ".gitignore"
+      - "ChangeLog"
+      - "LICENSES/**"
+      - "REUSE.toml"
   schedule:
     - cron: "0 1 2 * *"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ testpaths = test
 [tox:tox]
 min_version = 4.6.3
 env_list =
+    py314
     py313
     py312
     py311
@@ -56,6 +57,8 @@ commands =
 # For tox-gh
 [gh]
 python =
+    3.14 = py314
+    3.14-dev = py314
     3.13 = ruff-check, mypy-check, py313
     3.12 = py312
     3.11 = py311


### PR DESCRIPTION
A bunch of small adjustments to our CI infrastructure. All separate commits:

* CI: Update ignored paths for triggers
* CI: Update ignored paths for codeql workflow
* CI: Fail on windows or macos failures, too
* CI: Update hardcoded tool versions in workflow
* CI: Add Python 3.14 to matrix, + allow-prerelease
* tox: Add py314 to testenvs, plus tox-gh mappings

The hardcoded tools (the versions on the `python -m pip install` command line) are all updated to their latest release, after I checked that they all still support Python 3.9. (Or at least claim to.)

Python 3.14 is imminent but not quite out yet. The added `allow-prerelease` option to `actions/setup-python` will install `3.14-dev` for now, then automatically switch to `3.14` upon release.
