### PR TITLE
WIP: Create `dot`-launching pipeline for renders and other tasks, bypassing Pydot parser & API

### DIFF
--- a/src/pydot/__init__.py
+++ b/src/pydot/__init__.py
@@ -17,5 +17,19 @@ _logger.debug("pydot %s", __version__)
 
 
 from pydot.classes import FrozenDict  # noqa: F401, E402
-from pydot.core import *  # noqa: F403, E402
-from pydot.exceptions import *  # noqa: E402, F403
+from pydot.constants import (  # noqa: F401, E402
+    CLUSTER_ATTRIBUTES,
+    DEFAULT_PROGRAMS,
+    EDGE_ATTRIBUTES,
+    GRAPH_ATTRIBUTES,
+    NODE_ATTRIBUTES,
+    OUTPUT_FORMATS,
+)
+from pydot.core import *  # noqa: F401, F403, E402
+from pydot.exceptions import *  # noqa: F401, E402, F403
+from pydot.launcher import (  # noqa: F401, E402
+    call_graphviz,
+    get_executable_extension,
+    is_anaconda,
+    is_windows,
+)

--- a/src/pydot/constants.py
+++ b/src/pydot/constants.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Constants used by Pydot."""
+
+from __future__ import annotations
+
+# fmt: off
+GRAPH_ATTRIBUTES = {
+    "Damping", "K", "URL", "aspect", "bb", "bgcolor",
+    "center", "charset", "clusterrank", "colorscheme", "comment", "compound",
+    "concentrate", "defaultdist", "dim", "dimen", "diredgeconstraints",
+    "dpi", "epsilon", "esep", "fontcolor", "fontname", "fontnames",
+    "fontpath", "fontsize", "id", "label", "labeljust", "labelloc",
+    "landscape", "layers", "layersep", "layout", "levels", "levelsgap",
+    "lheight", "lp", "lwidth", "margin", "maxiter", "mclimit", "mindist",
+    "mode", "model", "mosek", "nodesep", "nojustify", "normalize", "nslimit",
+    "nslimit1", "ordering", "orientation", "outputorder", "overlap",
+    "overlap_scaling", "pack", "packmode", "pad", "page", "pagedir",
+    "quadtree", "quantum", "rankdir", "ranksep", "ratio", "remincross",
+    "repulsiveforce", "resolution", "root", "rotate", "searchsize", "sep",
+    "showboxes", "size", "smoothing", "sortv", "splines", "start",
+    "stylesheet", "target", "truecolor", "viewport", "voro_margin",
+    # for subgraphs
+    "rank"
+}
+
+
+EDGE_ATTRIBUTES = {
+    "URL", "arrowhead", "arrowsize", "arrowtail",
+    "color", "colorscheme", "comment", "constraint", "decorate", "dir",
+    "edgeURL", "edgehref", "edgetarget", "edgetooltip", "fontcolor",
+    "fontname", "fontsize", "headURL", "headclip", "headhref", "headlabel",
+    "headport", "headtarget", "headtooltip", "href", "id", "label",
+    "labelURL", "labelangle", "labeldistance", "labelfloat", "labelfontcolor",
+    "labelfontname", "labelfontsize", "labelhref", "labeltarget",
+    "labeltooltip", "layer", "len", "lhead", "lp", "ltail", "minlen",
+    "nojustify", "penwidth", "pos", "samehead", "sametail", "showboxes",
+    "style", "tailURL", "tailclip", "tailhref", "taillabel", "tailport",
+    "tailtarget", "tailtooltip", "target", "tooltip", "weight",
+    "rank"
+}
+
+
+NODE_ATTRIBUTES = {
+    "URL", "color", "colorscheme", "comment",
+    "distortion", "fillcolor", "fixedsize", "fontcolor", "fontname",
+    "fontsize", "group", "height", "id", "image", "imagescale", "label",
+    "labelloc", "layer", "margin", "nojustify", "orientation", "penwidth",
+    "peripheries", "pin", "pos", "rects", "regular", "root", "samplepoints",
+    "shape", "shapefile", "showboxes", "sides", "skew", "sortv", "style",
+    "target", "tooltip", "vertices", "width", "z",
+    # The following are attributes dot2tex
+    "texlbl",  "texmode"
+}
+
+
+CLUSTER_ATTRIBUTES = {
+    "K", "URL", "bgcolor", "color", "colorscheme",
+    "fillcolor", "fontcolor", "fontname", "fontsize", "label", "labeljust",
+    "labelloc", "lheight", "lp", "lwidth", "nojustify", "pencolor",
+    "penwidth", "peripheries", "sortv", "style", "target", "tooltip"
+}
+# fmt: on
+
+
+OUTPUT_FORMATS = {
+    "canon",
+    "cmap",
+    "cmapx",
+    "cmapx_np",
+    "dia",
+    "dot",
+    "fig",
+    "gd",
+    "gd2",
+    "gif",
+    "hpgl",
+    "imap",
+    "imap_np",
+    "ismap",
+    "jpe",
+    "jpeg",
+    "jpg",
+    "mif",
+    "mp",
+    "pcl",
+    "pdf",
+    "pic",
+    "plain",
+    "plain-ext",
+    "png",
+    "ps",
+    "ps2",
+    "svg",
+    "svgz",
+    "vml",
+    "vmlz",
+    "vrml",
+    "vtx",
+    "wbmp",
+    "xdot",
+    "xlib",
+}
+
+
+DEFAULT_PROGRAMS = {
+    "dot",
+    "twopi",
+    "neato",
+    "circo",
+    "fdp",
+    "sfdp",
+}

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -12,125 +12,23 @@ import itertools
 import logging
 import os
 import re
-import subprocess
-import sys
 import warnings
 from typing import Any, Sequence, Union, cast
 
 import pydot
 from pydot._vendor import tempfile
 from pydot.classes import AttributeDict, EdgeEndpoint, FrozenDict
+from pydot.constants import (
+    CLUSTER_ATTRIBUTES,
+    EDGE_ATTRIBUTES,
+    GRAPH_ATTRIBUTES,
+    NODE_ATTRIBUTES,
+    OUTPUT_FORMATS,
+)
+from pydot.launcher import call_graphviz
 
 _logger = logging.getLogger(__name__)
 _logger.debug("pydot core module initializing")
-
-# fmt: off
-GRAPH_ATTRIBUTES = {
-    "Damping", "K", "URL", "aspect", "bb", "bgcolor",
-    "center", "charset", "clusterrank", "colorscheme", "comment", "compound",
-    "concentrate", "defaultdist", "dim", "dimen", "diredgeconstraints",
-    "dpi", "epsilon", "esep", "fontcolor", "fontname", "fontnames",
-    "fontpath", "fontsize", "id", "label", "labeljust", "labelloc",
-    "landscape", "layers", "layersep", "layout", "levels", "levelsgap",
-    "lheight", "lp", "lwidth", "margin", "maxiter", "mclimit", "mindist",
-    "mode", "model", "mosek", "nodesep", "nojustify", "normalize", "nslimit",
-    "nslimit1", "ordering", "orientation", "outputorder", "overlap",
-    "overlap_scaling", "pack", "packmode", "pad", "page", "pagedir",
-    "quadtree", "quantum", "rankdir", "ranksep", "ratio", "remincross",
-    "repulsiveforce", "resolution", "root", "rotate", "searchsize", "sep",
-    "showboxes", "size", "smoothing", "sortv", "splines", "start",
-    "stylesheet", "target", "truecolor", "viewport", "voro_margin",
-    # for subgraphs
-    "rank"
-}
-
-
-EDGE_ATTRIBUTES = {
-    "URL", "arrowhead", "arrowsize", "arrowtail",
-    "color", "colorscheme", "comment", "constraint", "decorate", "dir",
-    "edgeURL", "edgehref", "edgetarget", "edgetooltip", "fontcolor",
-    "fontname", "fontsize", "headURL", "headclip", "headhref", "headlabel",
-    "headport", "headtarget", "headtooltip", "href", "id", "label",
-    "labelURL", "labelangle", "labeldistance", "labelfloat", "labelfontcolor",
-    "labelfontname", "labelfontsize", "labelhref", "labeltarget",
-    "labeltooltip", "layer", "len", "lhead", "lp", "ltail", "minlen",
-    "nojustify", "penwidth", "pos", "samehead", "sametail", "showboxes",
-    "style", "tailURL", "tailclip", "tailhref", "taillabel", "tailport",
-    "tailtarget", "tailtooltip", "target", "tooltip", "weight",
-    "rank"
-}
-
-
-NODE_ATTRIBUTES = {
-    "URL", "color", "colorscheme", "comment",
-    "distortion", "fillcolor", "fixedsize", "fontcolor", "fontname",
-    "fontsize", "group", "height", "id", "image", "imagescale", "label",
-    "labelloc", "layer", "margin", "nojustify", "orientation", "penwidth",
-    "peripheries", "pin", "pos", "rects", "regular", "root", "samplepoints",
-    "shape", "shapefile", "showboxes", "sides", "skew", "sortv", "style",
-    "target", "tooltip", "vertices", "width", "z",
-    # The following are attributes dot2tex
-    "texlbl",  "texmode"
-}
-
-
-CLUSTER_ATTRIBUTES = {
-    "K", "URL", "bgcolor", "color", "colorscheme",
-    "fillcolor", "fontcolor", "fontname", "fontsize", "label", "labeljust",
-    "labelloc", "lheight", "lp", "lwidth", "nojustify", "pencolor",
-    "penwidth", "peripheries", "sortv", "style", "target", "tooltip"
-}
-# fmt: on
-
-
-OUTPUT_FORMATS = {
-    "canon",
-    "cmap",
-    "cmapx",
-    "cmapx_np",
-    "dia",
-    "dot",
-    "fig",
-    "gd",
-    "gd2",
-    "gif",
-    "hpgl",
-    "imap",
-    "imap_np",
-    "ismap",
-    "jpe",
-    "jpeg",
-    "jpg",
-    "mif",
-    "mp",
-    "pcl",
-    "pdf",
-    "pic",
-    "plain",
-    "plain-ext",
-    "png",
-    "ps",
-    "ps2",
-    "svg",
-    "svgz",
-    "vml",
-    "vmlz",
-    "vrml",
-    "vtx",
-    "wbmp",
-    "xdot",
-    "xlib",
-}
-
-
-DEFAULT_PROGRAMS = {
-    "dot",
-    "twopi",
-    "neato",
-    "circo",
-    "fdp",
-    "sfdp",
-}
 
 
 class frozendict(FrozenDict):
@@ -195,73 +93,6 @@ def __generate_format_methods(Klass: type) -> None:
             self.write(path, format=f, prog=prog, encoding=encoding)
 
         setattr(Klass, f"write_{frmt}", __write_method)
-
-
-def is_windows() -> bool:
-    return os.name == "nt"
-
-
-def is_anaconda() -> bool:
-    import glob
-
-    conda_pattern = os.path.join(sys.prefix, "conda-meta\\graphviz*.json")
-    return glob.glob(conda_pattern) != []
-
-
-def get_executable_extension() -> str:
-    if is_windows():
-        return ".bat" if is_anaconda() else ".exe"
-    else:
-        return ""
-
-
-def call_graphviz(
-    program: str,
-    arguments: list[str],
-    working_dir: str | bytes,
-    **kwargs: Any,
-) -> tuple[bytes, bytes, subprocess.Popen[bytes]]:
-    if program in DEFAULT_PROGRAMS:
-        extension = get_executable_extension()
-        program += extension
-
-    if arguments is None:
-        arguments = []
-
-    if "creationflags" not in kwargs and hasattr(
-        subprocess, "CREATE_NO_WINDOW"
-    ):
-        # Only on Windows OS:
-        # specify that the new process shall not create a new window
-        kwargs.update(creationflags=subprocess.CREATE_NO_WINDOW)
-
-    # explicitly inherit `$PATH`, on Windows too,
-    # with `shell=False`
-    env = {
-        "PATH": os.environ.get("PATH", ""),
-        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
-        "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),
-    }
-
-    program_with_args = [program] + arguments
-
-    if sys.version_info < (3, 9):
-        my_popen = subprocess.Popen  # pragma: no cover
-    else:
-        my_popen = subprocess.Popen[bytes]
-
-    process = my_popen(
-        program_with_args,
-        env=env,
-        cwd=working_dir,
-        shell=False,
-        stderr=subprocess.PIPE,
-        stdout=subprocess.PIPE,
-        **kwargs,
-    )
-    stdout_data, stderr_data = process.communicate()
-
-    return stdout_data, stderr_data, process
 
 
 def make_quoted(s: str) -> str:
@@ -1838,9 +1669,9 @@ class Dot(Graph):
                 )
             except OSError as e:
                 if e.errno == errno.ENOENT:
-                    args = list(e.args)  # type: ignore
-                    args[1] = f'"{prog}" not found in path.'  # type: ignore
-                    raise OSError(*args)
+                    err_args: list[str] = list(e.args)
+                    err_args[1] = f'"{prog}" not found in path.'
+                    raise OSError(*err_args)
                 else:
                     raise  # pragma: no cover
 

--- a/src/pydot/launcher.py
+++ b/src/pydot/launcher.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2025 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Functions to run Graphviz tools in a subprocess and process results."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import typing as T
+
+from pydot.constants import DEFAULT_PROGRAMS
+
+
+def is_windows() -> bool:
+    return os.name == "nt"
+
+
+def is_anaconda() -> bool:
+    import glob
+
+    conda_pattern = os.path.join(sys.prefix, "conda-meta\\graphviz*.json")
+    return glob.glob(conda_pattern) != []
+
+
+def get_executable_extension() -> str:
+    if is_windows():
+        return ".bat" if is_anaconda() else ".exe"
+    else:
+        return ""
+
+
+def call_graphviz(
+    program: str,
+    arguments: list[str],
+    working_dir: str | bytes,
+    **kwargs: T.Any,
+) -> tuple[bytes, bytes, subprocess.Popen[bytes]]:
+    if program in DEFAULT_PROGRAMS:
+        extension = get_executable_extension()
+        program += extension
+
+    if arguments is None:
+        arguments = []
+
+    if "creationflags" not in kwargs and hasattr(
+        subprocess, "CREATE_NO_WINDOW"
+    ):
+        # Only on Windows OS:
+        # specify that the new process shall not create a new window
+        kwargs.update(creationflags=subprocess.CREATE_NO_WINDOW)
+
+    # explicitly inherit `$PATH`, on Windows too,
+    # with `shell=False`
+    env = {
+        "PATH": os.environ.get("PATH", ""),
+        "LD_LIBRARY_PATH": os.environ.get("LD_LIBRARY_PATH", ""),
+        "SYSTEMROOT": os.environ.get("SYSTEMROOT", ""),
+    }
+
+    program_with_args = [program] + arguments
+
+    if sys.version_info < (3, 9):
+        my_popen = subprocess.Popen  # pragma: no cover
+    else:
+        my_popen = subprocess.Popen[bytes]
+
+    process = my_popen(
+        program_with_args,
+        env=env,
+        cwd=working_dir,
+        shell=False,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        **kwargs,
+    )
+    stdout_data, stderr_data = process.communicate()
+
+    return stdout_data, stderr_data, process


### PR DESCRIPTION
As discussed in #507, begin work on a rendering pipeline for Pydot that can work directly off of `.gv` files or graph-definition strings, passing them into `dot` (or another GraphViz command) as-is rather than first running them through the parser, creating `pydot.core` objects, and then dumping the structure _back_ to `.gv` format with `.to_string()`. Mostly because that process is horribly inefficient, if you already have GraphViz syntax and don't **need** `pydot.core` objects.

Early days, only thing done so far is to split out parts of `core.py` into separate files, for importing-elsewhere purposes.

### The plan

- [x] Relocate the constants (`OUTPUT_FORMATS`, `DEFAULT_PROGRAMS`, etc.) to `src/pydot/constants.py`, and import where needed in other code
- [x] Relocate `call_graphviz` and its support functions to `src/pydot/launcher.py`, importing where needed (`core.py`)
- [ ] Create `src/pydot/renderer.py` containing functions which use `call_graphviz` to generate output files in various `dot -T` formats
  - [ ] Should accept `pydot.core.Dot` / `pydot.core.Graph` objects, and render to a temporary file using `.to_string()` that then gets passed to `dot`
  - [ ] Should accept `.gv` file paths, and pass them directly to `dot` as input files
  - [ ] Should accept strings containing Dot-syntax graph definitions, and write to a temporary file that's passed to `dot`.
  - [ ] Should allow output filenames to be specified (see discussion at #507)
  - [ ] Should allow the working directory for the process to be specified
- [ ] Tests, to some extent? (We don't want to run _all_ of our test files this way, because they're how we test the parser, but trying a few would be prudent.)