### PR TITLE
Drop support for Python 3.9 (EOL)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,6 @@ jobs:
           - "3.12"
           - "3.11"
           - "3.10"
-          - "3.9"
 
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0

--- a/ChangeLog
+++ b/ChangeLog
@@ -9,7 +9,7 @@ Pydot versions since 1.4.2 adhere to [PEP 440-style semantic versioning]
 4.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Dropped support for Python 3.8 and 3.9, as they are now end-of-life. (#539)
 
 
 4.0.1 (2025-06-17)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To see what Graphviz is capable of, check the [Graphviz Gallery](https://graphvi
 
 ## Dependencies
 
-- Python: The latest version of pydot supports Python 3.9+. It may work with Python 3.6-3.8, but we can't guarantee full support. If you're using one of these older versions, feel free to experiment, but we won't be able to address issues specific to them. Older versions of pydot are also an option.
+- Python: The latest version of pydot supports Python 3.10+. It may work with Python 3.6-3.9, but we can't guarantee full support. If you're using one of these older versions, feel free to experiment, but we won't be able to address issues specific to them. Older versions of pydot are also an option.
 - [`pyparsing`][pyparsing]: used only for *loading* DOT files, installed automatically during `pydot` installation.
 - GraphViz: used to render graphs in a variety of formats, including PNG, SVG, PDF, and more.
   Should be installed separately, using your system's [package manager][pkg], something similar (e.g., [MacPorts][mac]), or from [its source][src].

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ license = "MIT"
 license-files = [
    'LICENSES/*',
 ]
-requires-python = ">= 3.8"
+requires-python = ">= 3.10"
 dependencies = [
   'pyparsing>=3.1.0'
 ]
@@ -36,7 +36,6 @@ classifiers = [
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,6 @@ env_list =
     py312
     py311
     py310
-    py39
     ruff-check
     mypy-check
 
@@ -31,7 +30,7 @@ package = wheel
 wheel_build_env = .pkg
 pass_env =
     TEST_ERROR_DIR
-setenv = 
+setenv =
     DEFAULT_COVERAGE_FILE = .coverage.{envname}
     COVERAGE_FILE = {env:COVERAGE_FILE:{env:DEFAULT_COVERAGE_FILE}}
 commands = pytest -n auto --cov {posargs}
@@ -39,7 +38,7 @@ commands = pytest -n auto --cov {posargs}
 [testenv:ruff-check]
 skip_install = true
 deps = ruff==0.7.3
-commands = 
+commands =
     ruff format --diff .
     ruff check . {posargs}
 
@@ -63,5 +62,4 @@ python =
     3.13 = py313
     3.12 = py312
     3.11 = py311
-    3.10 = py310
-    3.9 = mypy-check, py39
+    3.10 = mypy-check, py310

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -245,12 +245,7 @@ def call_graphviz(
 
     program_with_args = [program] + arguments
 
-    if sys.version_info < (3, 9):
-        my_popen = subprocess.Popen  # pragma: no cover
-    else:
-        my_popen = subprocess.Popen[bytes]
-
-    process = my_popen(
+    process = subprocess.Popen[bytes](
         program_with_args,
         env=env,
         cwd=working_dir,

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -122,14 +122,8 @@ def _load_test_cases(casedir: str) -> Generator[tuple[str, str, str]]:
     path = os.path.join(_test_root, casedir)
     dot_files = filter(lambda x: x.endswith(".dot"), os.listdir(path))
 
-    def _case_name(fname: str) -> str:
-        """No str.removesuffix() until Python 3.9."""
-        if sys.version_info < (3, 9):  # pragma: no cover
-            return fname
-        return fname.removesuffix(".dot")
-
     for dot_file in dot_files:
-        yield (_case_name(dot_file), dot_file, path)
+        yield (dot_file.removesuffix(".dot"), dot_file, path)
 
 
 def _compare_images(


### PR DESCRIPTION
Python 3.9 Eind of life was at 2025-10-31 (https://devguide.python.org/versions/). This drops support for `python<3.10`, and removes the relevant code paths.

