### PR TITLE
100% type coverage and improved annotations

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -952,6 +952,7 @@ class Edge(Common):
 
 __generate_attribute_methods(Edge, EDGE_ATTRIBUTES)
 
+
 class Graph(Common):
     """Class representing a graph in Graphviz's dot language.
 

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -15,12 +15,12 @@ import re
 import subprocess
 import sys
 import warnings
-from typing import TYPE_CHECKING, Any, Final, Sequence, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Sequence, Union, cast
 
 if TYPE_CHECKING:
     # `typing_extensions` is always available in `TYPE_CHECKING` blocks,
     # even if not  installed
-    from typing_extensions import TypeAlias
+    from typing_extensions import Self, TypeAlias
 
 import pydot
 from pydot._vendor import tempfile
@@ -952,9 +952,6 @@ class Edge(Common):
 
 __generate_attribute_methods(Edge, EDGE_ATTRIBUTES)
 
-TGraph = TypeVar("TGraph", bound="Graph")
-
-
 class Graph(Common):
     """Class representing a graph in Graphviz's dot language.
 
@@ -1134,7 +1131,7 @@ class Graph(Common):
         self.obj_dict["current_child_sequence"] = seq + 1
         return seq
 
-    def __enter__(self: TGraph) -> TGraph:
+    def __enter__(self) -> Self:
         """Enter the runtime context for this graph.
 
         Enables a nested construction style:

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -15,7 +15,12 @@ import re
 import subprocess
 import sys
 import warnings
-from typing import Any, Sequence, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Final, Sequence, TypeVar, Union, cast
+
+if TYPE_CHECKING:
+    # `typing_extensions` is always available in `TYPE_CHECKING` blocks,
+    # even if not  installed
+    from typing_extensions import TypeAlias
 
 import pydot
 from pydot._vendor import tempfile
@@ -25,7 +30,7 @@ _logger = logging.getLogger(__name__)
 _logger.debug("pydot core module initializing")
 
 # fmt: off
-GRAPH_ATTRIBUTES = {
+GRAPH_ATTRIBUTES: Final = {
     "Damping", "K", "URL", "aspect", "bb", "bgcolor",
     "center", "charset", "clusterrank", "colorscheme", "comment", "compound",
     "concentrate", "defaultdist", "dim", "dimen", "diredgeconstraints",
@@ -45,7 +50,7 @@ GRAPH_ATTRIBUTES = {
 }
 
 
-EDGE_ATTRIBUTES = {
+EDGE_ATTRIBUTES: Final = {
     "URL", "arrowhead", "arrowsize", "arrowtail",
     "color", "colorscheme", "comment", "constraint", "decorate", "dir",
     "edgeURL", "edgehref", "edgetarget", "edgetooltip", "fontcolor",
@@ -61,7 +66,7 @@ EDGE_ATTRIBUTES = {
 }
 
 
-NODE_ATTRIBUTES = {
+NODE_ATTRIBUTES: Final = {
     "URL", "color", "colorscheme", "comment",
     "distortion", "fillcolor", "fixedsize", "fontcolor", "fontname",
     "fontsize", "group", "height", "id", "image", "imagescale", "label",
@@ -74,7 +79,7 @@ NODE_ATTRIBUTES = {
 }
 
 
-CLUSTER_ATTRIBUTES = {
+CLUSTER_ATTRIBUTES: Final = {
     "K", "URL", "bgcolor", "color", "colorscheme",
     "fillcolor", "fontcolor", "fontname", "fontsize", "label", "labeljust",
     "labelloc", "lheight", "lp", "lwidth", "nojustify", "pencolor",
@@ -83,7 +88,7 @@ CLUSTER_ATTRIBUTES = {
 # fmt: on
 
 
-OUTPUT_FORMATS = {
+OUTPUT_FORMATS: Final = {
     "canon",
     "cmap",
     "cmapx",
@@ -123,7 +128,7 @@ OUTPUT_FORMATS = {
 }
 
 
-DEFAULT_PROGRAMS = {
+DEFAULT_PROGRAMS: Final = {
     "dot",
     "twopi",
     "neato",
@@ -136,7 +141,7 @@ DEFAULT_PROGRAMS = {
 class frozendict(FrozenDict):
     """Deprecated alias for pydot.classes.FrozenDict."""
 
-    def __init__(self, *args: Any, **kwargs: Any):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         warnings.warn(
             f"{self.__class__.__name__} is deprecated. "
             "Use pydot.classes.FrozenDict instead.",
@@ -276,15 +281,19 @@ def make_quoted(s: str) -> str:
 
 dot_keywords = ["graph", "subgraph", "digraph", "node", "edge", "strict"]
 
-re_numeric = re.compile(r"^([0-9]+\.?[0-9]*|[0-9]*\.[0-9]+)$")
-re_dbl_quoted = re.compile(r'^".*"$', re.S)
-re_html = re.compile(r"^<.*>$", re.S)
+re_numeric: Final[re.Pattern[str]] = re.compile(
+    r"^([0-9]+\.?[0-9]*|[0-9]*\.[0-9]+)$"
+)
+re_dbl_quoted: Final[re.Pattern[str]] = re.compile(r'^".*"$', re.S)
+re_html: Final[re.Pattern[str]] = re.compile(r"^<.*>$", re.S)
 
-id_re_alpha_nums = re.compile(r"^[_a-zA-Z][a-zA-Z0-9_]*$")
-id_re_alpha_nums_with_ports = re.compile(
+id_re_alpha_nums: Final[re.Pattern[str]] = re.compile(
+    r"^[_a-zA-Z][a-zA-Z0-9_]*$"
+)
+id_re_alpha_nums_with_ports: Final[re.Pattern[str]] = re.compile(
     r'^[_a-zA-Z][a-zA-Z0-9_:"]*[a-zA-Z0-9_"]+$'
 )
-id_re_with_port = re.compile(r"^([^:]*):([^:]*)$")
+id_re_with_port: Final[re.Pattern[str]] = re.compile(r"^([^:]*):([^:]*)$")
 
 
 def any_needs_quotes(s: str) -> bool | None:
@@ -1675,10 +1684,14 @@ class Dot(Graph):
     the base class 'Graph'.
     """
 
+    shape_files: list[str]
+    formats: set[str]
+    prog: str
+
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
 
-        self.shape_files: list[str] = []
+        self.shape_files = []
         self.formats = OUTPUT_FORMATS
         self.prog = "dot"
 
@@ -1897,4 +1910,4 @@ __generate_format_methods(Dot)
 
 
 # Type alias for forward-referenced type
-EdgeDefinition = Union[EdgeEndpoint, Node, Subgraph, Cluster]
+EdgeDefinition: TypeAlias = Union[EdgeEndpoint, Node, Subgraph, Cluster]

--- a/src/pydot/dot_parser.py
+++ b/src/pydot/dot_parser.py
@@ -15,7 +15,7 @@ Fixes by: Ero Carrera <ero.carrera@gmail.com>
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, ClassVar, Final, cast
 
 from pyparsing import (
     CaselessLiteral,
@@ -52,12 +52,14 @@ _logger.debug("pydot dot_parser module initializing")
 
 
 class P_AttrList:
+    attrs: dict[str, Any]
+
     def __init__(self, toks: ParseResults) -> None:
         self.attrs = {}
         i = 0
 
         while i < len(toks):
-            attrname = toks[i]
+            attrname = cast(str, toks[i])
             if i + 2 < len(toks) and toks[i + 1] == "=":
                 attrvalue = toks[i + 2]
                 i += 3
@@ -73,7 +75,9 @@ class P_AttrList:
 
 
 class DefaultStatement(P_AttrList):
-    def __init__(self, default_type: str, attrs: Any) -> None:
+    default_type: Final[str]
+
+    def __init__(self, default_type: str, attrs: dict[str, Any]) -> None:
         self.default_type = default_type
         self.attrs = attrs
 
@@ -261,88 +265,94 @@ class GraphParser:
     """Pyparsing grammar for graphviz 'dot' syntax."""
 
     # punctuation
-    colon = Literal(":")
-    lbrace = Literal("{")
-    rbrace = Literal("}")
-    lbrack = Literal("[")
-    rbrack = Literal("]")
-    equals = Literal("=")
-    comma = Literal(",")
-    semi = Literal(";")
-    minus = Literal("-")
+    colon: ClassVar[Literal] = Literal(":")
+    lbrace: ClassVar[Literal] = Literal("{")
+    rbrace: ClassVar[Literal] = Literal("}")
+    lbrack: ClassVar[Literal] = Literal("[")
+    rbrack: ClassVar[Literal] = Literal("]")
+    equals: ClassVar[Literal] = Literal("=")
+    comma: ClassVar[Literal] = Literal(",")
+    semi: ClassVar[Literal] = Literal(";")
+    minus: ClassVar[Literal] = Literal("-")
 
     # keywords
-    strict_ = CaselessLiteral("strict")
-    graph_ = CaselessLiteral("graph")
-    digraph_ = CaselessLiteral("digraph")
-    subgraph_ = CaselessLiteral("subgraph")
-    node_ = CaselessLiteral("node")
-    edge_ = CaselessLiteral("edge")
+    strict_: ClassVar[CaselessLiteral] = CaselessLiteral("strict")
+    graph_: ClassVar[CaselessLiteral] = CaselessLiteral("graph")
+    digraph_: ClassVar[CaselessLiteral] = CaselessLiteral("digraph")
+    subgraph_: ClassVar[CaselessLiteral] = CaselessLiteral("subgraph")
+    node_: ClassVar[CaselessLiteral] = CaselessLiteral("node")
+    edge_: ClassVar[CaselessLiteral] = CaselessLiteral("edge")
 
     # token definitions
-    identifier = Word(unicode.BasicMultilingualPlane.alphanums + "_.")
+    identifier: ClassVar[Word] = Word(
+        unicode.BasicMultilingualPlane.alphanums + "_."
+    )
 
-    double_quoted = (
+    double_quoted: ClassVar[ParserElement] = (
         QuotedString('"', multiline=True, unquote_results=False, esc_char="\\")
         .set_results_name("dbl_quoted")
         .set_parse_action(push_dbl_quoted)
     )
 
-    concat_string = DelimitedList(
+    concat_string: ClassVar[DelimitedList] = DelimitedList(
         double_quoted, delim="+", min=2, combine=False
     )
 
-    ID = (
+    ID: ClassVar[ParserElement] = (
         concat_string("concat")
         | double_quoted
         | identifier("ident")
         | HTML().set_results_name("html")
     ).set_parse_action(push_ID)
 
-    float_number = Combine(Optional(minus) + OneOrMore(Word(nums + ".")))
+    float_number: ClassVar[Combine] = Combine(
+        Optional(minus) + OneOrMore(Word(nums + "."))
+    )
 
-    righthand_id = float_number | ID
+    righthand_id: ClassVar[ParserElement] = float_number | ID
 
-    node_id = DelimitedList(
+    node_id: ClassVar[ParserElement] = DelimitedList(
         Group(ID("id_part")), delim=":", min=1, max=3, combine=False
     ).set_parse_action(push_node_id)
 
-    a_list = OneOrMore(
+    a_list: ClassVar[OneOrMore] = OneOrMore(
         ID + Optional(equals + righthand_id) + Optional(comma.suppress())
     )
-    attr_list = OneOrMore(
+    attr_list: ClassVar[OneOrMore] = OneOrMore(
         lbrack.suppress() + Optional(a_list) + rbrack.suppress()
     )
-    node_stmt = (
+    node_stmt: ClassVar[ParserElement] = (
         node_id("name")
         + Optional(attr_list("attr_l"))
         + Optional(semi.suppress())
     )
 
-    default_type = graph_ | node_ | edge_
-    default_stmt = default_type("dtype") + attr_list("attr_l")
+    default_type: ClassVar[ParserElement] = graph_ | node_ | edge_
+    default_stmt: ClassVar[ParserElement] = default_type("dtype") + attr_list(
+        "attr_l"
+    )
 
-    stmt_list = Forward()
-    graph_stmt = Group(
+    stmt_list: ClassVar[Forward] = Forward()
+    graph_stmt: ClassVar[Group] = Group(
         lbrace.suppress()
         + Optional(stmt_list)
         + rbrace.suppress()
         + Optional(semi.suppress())
     )
 
-    subgraph = (
+    subgraph: ClassVar[ParserElement] = (
         subgraph_("keyword") + Optional(ID("id")) + graph_stmt("contents")
     )
 
-    edgeop = Literal("--") | Literal("->")
-    edge_point = subgraph | graph_stmt | node_id
-    edge_stmt = DelimitedList(edge_point, delim=edgeop, min=2)(
-        "endpoints"
-    ) + Optional(attr_list("attr_l"))
+    edgeop: ClassVar[ParserElement] = Literal("--") | Literal("->")
+    edge_point: ClassVar[ParserElement] = subgraph | graph_stmt | node_id
+    edge_stmt: ClassVar[ParserElement] = DelimitedList(
+        edge_point, delim=edgeop, min=2
+    )("endpoints") + Optional(attr_list("attr_l"))
 
-    assignment = ID + equals + righthand_id
+    assignment: ClassVar[ParserElement] = ID + equals + righthand_id
 
-    stmt = (
+    stmt: ClassVar[ParserElement] = (
         assignment
         | edge_stmt
         | default_stmt
@@ -352,8 +362,8 @@ class GraphParser:
     )
     stmt_list <<= OneOrMore(stmt + Optional(semi.suppress()))
 
-    graph_type = digraph_ | graph_
-    parser = OneOrMore(
+    graph_type: ClassVar[ParserElement] = digraph_ | graph_
+    parser: ClassVar[ParserElement] = OneOrMore(
         Group(
             Optional(strict_("strict"))
             + graph_type("gtype")
@@ -362,9 +372,9 @@ class GraphParser:
         )
     ).set_results_name("graphs")
 
-    single_line_comment = Group("//" + rest_of_line) | Group(
-        "#" + rest_of_line
-    )
+    single_line_comment: ClassVar[ParserElement] = Group(
+        "//" + rest_of_line
+    ) | Group("#" + rest_of_line)
 
     # actions
 
@@ -405,4 +415,4 @@ def parse_dot_data(s: str) -> list[pydot.core.Dot] | None:
 
 
 # Backwards compatibility
-graphparser: ParserElement = GraphParser.parser
+graphparser: Final[ParserElement] = GraphParser.parser

--- a/src/pydot/exceptions.py
+++ b/src/pydot/exceptions.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from typing import Final
+
 
 class PydotException(Exception):
     """Base class for exceptions in Pydot.
@@ -20,6 +22,8 @@ class PydotException(Exception):
 
 class Error(PydotException):
     """General error handling class."""
+
+    value: Final[str]
 
     def __init__(self, value: str) -> None:
         self.value = value

--- a/src/pydot/exceptions.py
+++ b/src/pydot/exceptions.py
@@ -6,8 +6,6 @@
 
 from __future__ import annotations
 
-from typing import Final
-
 
 class PydotException(Exception):
     """Base class for exceptions in Pydot.
@@ -23,7 +21,7 @@ class PydotException(Exception):
 class Error(PydotException):
     """General error handling class."""
 
-    value: Final[str]
+    value: str
 
     def __init__(self, value: str) -> None:
         self.value = value


### PR DESCRIPTION
I noticed on the typestats dashboard ([url](https://jorenham.github.io/typestats/dashboard/report/#pydot)) that `pydot` has 86% type coverage. So I figured I might as well help out and bring that to 100% :)

Before:

```bash
$ uvx typestats check pydot
untyped (44):
pydot/core.py:279        re_numeric
pydot/core.py:280        re_dbl_quoted
pydot/core.py:281        re_html
pydot/core.py:283        id_re_alpha_nums
pydot/core.py:284        id_re_alpha_nums_with_ports
pydot/core.py:287        id_re_with_port
pydot/core.py:1658       Dot.formats
pydot/core.py:1659       Dot.prog
pydot/dot_parser.py:56   P_AttrList.attrs
pydot/dot_parser.py:77   DefaultStatement.default_type
pydot/dot_parser.py:78   DefaultStatement.attrs
pydot/dot_parser.py:264  GraphParser.colon
pydot/dot_parser.py:265  GraphParser.lbrace
pydot/dot_parser.py:266  GraphParser.rbrace
pydot/dot_parser.py:267  GraphParser.lbrack
pydot/dot_parser.py:268  GraphParser.rbrack
pydot/dot_parser.py:269  GraphParser.equals
pydot/dot_parser.py:270  GraphParser.comma
pydot/dot_parser.py:271  GraphParser.semi
pydot/dot_parser.py:272  GraphParser.minus
pydot/dot_parser.py:275  GraphParser.strict_
pydot/dot_parser.py:276  GraphParser.graph_
pydot/dot_parser.py:277  GraphParser.digraph_
pydot/dot_parser.py:278  GraphParser.subgraph_
pydot/dot_parser.py:279  GraphParser.node_
pydot/dot_parser.py:280  GraphParser.edge_
pydot/dot_parser.py:283  GraphParser.identifier
pydot/dot_parser.py:285  GraphParser.double_quoted
pydot/dot_parser.py:291  GraphParser.concat_string
pydot/dot_parser.py:295  GraphParser.ID
pydot/dot_parser.py:302  GraphParser.float_number
pydot/dot_parser.py:306  GraphParser.node_id
pydot/dot_parser.py:310  GraphParser.a_list
pydot/dot_parser.py:313  GraphParser.attr_list
pydot/dot_parser.py:316  GraphParser.node_stmt
pydot/dot_parser.py:323  GraphParser.default_stmt
pydot/dot_parser.py:325  GraphParser.stmt_list
pydot/dot_parser.py:326  GraphParser.graph_stmt
pydot/dot_parser.py:333  GraphParser.subgraph
pydot/dot_parser.py:337  GraphParser.edgeop
pydot/dot_parser.py:339  GraphParser.edge_stmt
pydot/dot_parser.py:356  GraphParser.parser
pydot/dot_parser.py:365  GraphParser.single_line_comment
pydot/exceptions.py:25   Error.value

coverage:   86.03%
typable:    315
typed:      226
any:         45
```

After:

```bash
$ uvx typestats check pydot
coverage:   100.00%
typable:    327
typed:      283
any:         44
```

---

While I was working on this, I was also using [pyrefly](https://github.com/facebook/pyrefly), which helped spot some other minor opportunities for improvements here and there. Some of those I included in here. Others, such as making `FrozenDict` a [generic type](https://typing.python.org/en/latest/reference/generics.html) will have to wait #539 to avoid it from becoming a mess.

Either way, if you're open to it, maybe it's an idea to (also) use pyrefly as type-checker? Personally I prefer it over mypy, and in my experience pyrefly and mypy can play very well together, complementing each other even. So if you're up for it I could add pyrefly as a follow-up, or perhaps even in this PR?