### PR TITLE
API: Add context manager for graphs

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1143,7 +1143,7 @@ class Graph(Common):
         """Exit the runtime context for this graph.
 
         Performs no cleanup.
-        Always returns `False`, so exceptions are never suppressed.
+        Always returns `None`, so exceptions are never suppressed.
         """
         return
 

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -15,7 +15,7 @@ import re
 import subprocess
 import sys
 import warnings
-from typing import Any, Sequence, Union, cast
+from typing import Any, Sequence, TypeVar, Union, cast
 
 import pydot
 from pydot._vendor import tempfile
@@ -943,6 +943,8 @@ class Edge(Common):
 
 __generate_attribute_methods(Edge, EDGE_ATTRIBUTES)
 
+TGraph = TypeVar("TGraph", bound="Graph")
+
 
 class Graph(Common):
     """Class representing a graph in Graphviz's dot language.
@@ -1122,6 +1124,28 @@ class Graph(Common):
         seq: int = self.obj_dict.get("current_child_sequence", 1)
         self.obj_dict["current_child_sequence"] = seq + 1
         return seq
+
+    def __enter__(self: TGraph) -> TGraph:
+        """Enter the runtime context for this graph.
+
+        Enables a nested construction style:
+
+            with Dot("A") as dot:
+                with Subgraph("B") as sg:
+                    sg.add_node(Node("N1"))
+                    dot.add_subgraph(sg)
+
+        This is syntactic sugar only with no side effects.
+        """
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the runtime context for this graph.
+
+        Performs no cleanup.
+        Always returns `False`, so exceptions are never suppressed.
+        """
+        return
 
     def add_node(self, graph_node: Node) -> None:
         """Adds a node object to the graph.

--- a/test/test_context_managers.py
+++ b/test/test_context_managers.py
@@ -1,0 +1,124 @@
+# SPDX-FileCopyrightText: 2026 pydot contributors
+#
+# SPDX-License-Identifier: MIT
+
+"""Unit testing of context manager support in pydot."""
+
+from __future__ import annotations
+
+import pytest
+
+import pydot
+
+
+def test_context_manager_returns_exact_instance():
+    g_orig = pydot.Graph("G")
+    with g_orig as g_ctx:
+        assert g_orig is g_ctx
+
+    # Subsequent calls don't change anything
+    with g_orig as g_ctx:
+        assert g_orig is g_ctx
+    with g_orig as g_ctx:
+        assert g_orig is g_ctx
+
+
+def test_context_manager_empty_block():
+    with pydot.Graph("G") as g:
+        pass
+    assert g.get_name() == "G"
+    assert len(g.get_nodes()) == 0
+
+
+def test_context_manager_dot():
+    with pydot.Dot(graph_name="main", graph_type="digraph") as dot:
+        assert isinstance(dot, pydot.Dot)
+
+        node_a = pydot.Node("A")
+        node_b = pydot.Node("B")
+        edge_ab = pydot.Edge(node_a, node_b)
+
+        dot.add_node(node_a)
+        dot.add_node(node_b)
+        dot.add_edge(edge_ab)
+
+    assert dot.get_name() == "main"
+    assert len(dot.get_nodes()) == 2
+    assert len(dot.get_edges()) == 1
+    assert dot.get_nodes()[0].get_name() == "A"
+    assert dot.get_nodes()[1].get_name() == "B"
+
+
+def test_context_manager_graph():
+    with pydot.Graph(graph_name="G") as g:
+        assert isinstance(g, pydot.Graph)
+        g.add_node(pydot.Node("B"))
+
+    assert g.get_name() == "G"
+    assert len(g.get_nodes()) == 1
+
+
+def test_context_manager_subgraph():
+    with pydot.Subgraph(graph_name="sub") as sub:
+        assert isinstance(sub, pydot.Subgraph)
+        sub.add_node(pydot.Node("C"))
+
+    assert sub.get_name() == "sub"
+    assert len(sub.get_nodes()) == 1
+
+
+def test_context_manager_cluster():
+    with pydot.Cluster(graph_name="my_cluster") as cluster:
+        assert isinstance(cluster, pydot.Cluster)
+        cluster.add_node(pydot.Node("D"))
+
+    # Cluster name is prefixed with 'cluster_'
+    assert cluster.get_name() == "cluster_my_cluster"
+    assert len(cluster.get_nodes()) == 1
+
+
+def test_context_manager_nested_mixed():
+    dot = pydot.Dot("my_graph", graph_type="digraph")
+
+    with pydot.Cluster("my_cluster") as cluster:
+        cluster.add_node(pydot.Node("A"))
+        cluster.add_node(pydot.Node("B"))
+        dot.add_subgraph(cluster)
+
+        with pydot.Subgraph("nested_sub") as sub:
+            sub.add_node(pydot.Node("C"))
+            cluster.add_subgraph(sub)
+
+            with pydot.Cluster("deep_cluster") as deep:
+                deep.add_node(pydot.Node("D"))
+                sub.add_subgraph(deep)
+
+    assert len(dot.get_subgraphs()) == 1
+    cluster_obj = dot.get_subgraphs()[0]
+    assert cluster_obj.get_name() == "cluster_my_cluster"
+    assert len(cluster_obj.get_nodes()) == 2
+
+    assert len(cluster_obj.get_subgraphs()) == 1
+    sub_obj = cluster_obj.get_subgraphs()[0]
+    assert sub_obj.get_name() == "nested_sub"
+    assert len(sub_obj.get_nodes()) == 1
+    assert sub_obj.get_nodes()[0].get_name() == "C"
+
+    assert len(sub_obj.get_subgraphs()) == 1
+    deep_obj = sub_obj.get_subgraphs()[0]
+    assert deep_obj.get_name() == "cluster_deep_cluster"
+    assert len(deep_obj.get_nodes()) == 1
+    assert deep_obj.get_nodes()[0].get_name() == "D"
+
+
+def test_context_manager_exception_propagation():
+    # Context manager should not swallow exceptions
+    with pytest.raises(ValueError, match="test error"):
+        with pydot.Dot() as dot:
+            dot.add_node(pydot.Node("A"))
+            raise ValueError("test error")
+
+    # Even if exception occurred,
+    # the object is still accessible and preserved up to the failure
+    assert dot.get_name() == "G"  # Defaults to "G" when not specified
+    assert len(dot.get_nodes()) == 1


### PR DESCRIPTION
We can add simple context manager methods for graph classes. 
If you're working in an "imperative" way with non-enormous graphs, this allows for a nice nested workflow.
This doesn't change any existing code.
It doesn't add any management or cleanup, it's just a simple nesting provider.

Example:

```python
from pydot import Cluster, Dot, Edge, Node, Subgraph

with Dot("A") as dot:
    with Subgraph("B") as sg:
        sg.add_node(Node("N1"))
        sg.add_node(Node("N2"))
        sg.add_edge(Edge("N1", "N2"))
        dot.add_subgraph(sg)
    with Cluster("C") as c:
        c.add_node(Node("C1"))
        with Cluster("D") as d:
            d.add_node(Node("D1"))
            c.add_subgraph(d)
        dot.add_subgraph(c)

print(dot.to_string())
dot.write_png("test.png")
```

Results in:

```dot
digraph A {
subgraph B {
N1;
N2;
N1 -> N2;
}
subgraph cluster_C {
C1;
subgraph cluster_D {
D1;
}
}
}
```

<img width="304" height="187" alt="test" src="https://github.com/user-attachments/assets/e2e95a22-aee6-4944-8f70-4a3bce8a171e" />


