### PR TITLE
API: Validate graph_type in set_type()

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1081,6 +1081,11 @@ class Graph(Common):
 
     def set_type(self, graph_type: str) -> None:
         """Set the graph's type, 'graph' or 'digraph'."""
+        if graph_type not in ["graph", "digraph"]:
+            raise pydot.Error(
+                f'Invalid type "{graph_type}". '
+                "Accepted graph types are: graph, digraph"
+            )
         self.obj_dict["type"] = graph_type
 
     def get_type(self) -> str | None:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -662,6 +662,15 @@ def test_bad_graph_type() -> None:
     )
 
 
+def test_set_type_invalid() -> None:
+    g = pydot.Dot(graph_name="Test", graph_type="graph")
+    with pytest.raises(pydot.exceptions.Error) as e:
+        g.set_type("round")
+    assert str(e.value) == (
+        'Invalid type "round".' + " Accepted graph types are: graph, digraph"
+    )
+
+
 def test_sequence() -> None:
     g = pydot.Graph("G")
     for i in range(10):


### PR DESCRIPTION
`set_type()` accepted any string while the constructor already rejected unacceptable values.

This adds the same validation in `set_type()`