### PR TITLE
Make Cluster a subclass of Subgraph

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1394,9 +1394,7 @@ class Graph(Common):
         It takes a subgraph object as its only argument and returns
         None.
         """
-        if not isinstance(sgraph, Subgraph) and not isinstance(
-            sgraph, Cluster
-        ):
+        if not isinstance(sgraph, Subgraph):
             raise TypeError(
                 "add_subgraph() received a non subgraph class object:"
                 + str(sgraph)
@@ -1631,7 +1629,7 @@ class Subgraph(Graph):
             self.obj_dict["type"] = "subgraph"
 
 
-class Cluster(Graph):
+class Cluster(Subgraph):
     """Class representing a cluster in Graphviz's dot language.
 
     This class implements the methods to work on a representation
@@ -1678,7 +1676,6 @@ class Cluster(Graph):
             **attrs,
         )
         if obj_dict is None:
-            self.obj_dict["type"] = "subgraph"
             self.obj_dict["name"] = quote_id_if_necessary(
                 "cluster_" + graph_name
             )


### PR DESCRIPTION
We're not currently type-checking our test code.

That's something I'd like to change, and this is a perfect example of why.

If we _were_ type-checking our test code, then we'd have seen that every instance of this gets flagged as a type violation:

```python
import pydot
g = pydot.Graph("G")
c = pydot.Cluster("1")
g.add_subgraph(c)
```

`pydot.core.Graph.add_subgraph()` was type-annotated to only accept a `Subgraph` argument, which `Cluster` was not since they were both subclasses of `Graph`.

The other approach would've been to make `add_subgraph()` accept `Graph` arguments, and while there _is_ some degree of sense in that (it could theoretically be made to work), ultimately the code as it currently stands doesn't support that. `Graph.add_subgraph()` explicitly checks that the `obj_dict["graph_type"]` for its argument is `"subgraph"`, which was true for both `Subgraph` and `Cluster` but wold not generally be true for `pydot.Graph()`. So, clearly `Cluster` _is_ a `Subgraph`.