### PR TITLE
Sync Dot.write and Dot.create signatures

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1755,22 +1755,30 @@ class Dot(Graph):
     def write(
         self,
         path: str | bytes,
-        prog: str | None = None,
+        prog: list[str] | tuple[str] | str | None = None,
         format: str = "raw",
         encoding: str | None = None,
     ) -> bool:
         """Writes a graph to a file.
 
-        Given a filename 'path' it will open/create and truncate
-        that file and write to it a representation of the graph
-        defined by the dot object in the format specified by
-        'format' and using the encoding specified by `encoding` for text.
-        The format 'raw' is used to dump the string representation
-        of the Dot object, without further processing.
-        The output can be processed by any of graphviz tools, defined
-        in 'prog', which defaults to 'dot'
-        Returns True or False according to the success of the write
-        operation.
+        Creates/opens (and truncates) the file ``path``, and writes
+        to it a rendered representation of the current graph.
+
+        The file format can be specified with ``format``, which defaults
+        to ``raw`` (see below).
+
+        The encoding to use when writing the intermediate graph
+        definition can be set with ``encoding``. (The default is
+        ``utf-8``, which matches the data in memory and is almost
+        always what you want.)
+
+        The special ``format`` value ``raw`` is used to dump the generated
+        graph definition ("dotfile" source), without further processing.
+        (In ``raw`` mode, ``encoding`` can be used to set the encoding of
+        the output file.)
+
+        Returns True, or raises an exception if an error is encountered.
+        The exception is some form of ``OSError`` or an ``AssertionError``.
 
         There's also the preferred possibility of using:
 
@@ -1779,9 +1787,45 @@ class Dot(Graph):
         which are automatically defined for all the supported formats.
         [write_ps(), write_gif(), write_dia(), ...]
 
-        The encoding is passed to `open` [1].
+        The encoding is passed to ``open`` [1].
 
-        [1] https://docs.python.org/3/library/functions.html#open
+        [1]: https://docs.python.org/3/library/functions.html#open
+
+        @param prog:
+
+          One of:
+
+          - the name of Graphviz executable that
+            can be found in the ``$PATH``.
+
+          - the absolute path to Graphviz executable.
+
+          - a sequence (list, tuple) with the first
+            element being one of the above, and the
+            remaining elements being command-line
+            arguments to use when invoking the executable.
+
+          If you have added Graphviz to the ``$PATH`` and
+          use its executables as installed
+          (without renaming any of them)
+          then their names are:
+
+            - ``dot``
+            - ``twopi``
+            - ``neato``
+            - ``circo``
+            - ``fdp``
+            - ``sfdp``
+
+          On Windows, these have the notorious ".exe" extension that,
+          only for the above strings, will be added automatically.
+
+          The ``$PATH`` is inherited from ``os.env['PATH']`` and
+          passed to ``subprocess.Popen`` using the `env` argument.
+
+          If you haven't added Graphviz to your ``$PATH`` on Windows,
+          then you may want to give the absolute path to the
+          executable (for example, to ``dot.exe``) in ``prog``.
         """
         if prog is None:
             prog = self.prog
@@ -1803,10 +1847,20 @@ class Dot(Graph):
     ) -> bytes:
         """Creates and returns a binary image for the graph.
 
-        create will write the graph to a temporary dot file in the
-        encoding specified by `encoding` and process it with the
-        program given by 'prog' (which defaults to `self.prog`, initially
-        'dot'), reading the binary image output and returning it as `bytes`.
+        The program used to process the graph data is specified by
+        ``prog``, which defaults to ``self.prog`` (initially ``dot``).
+
+        The file format for the returned data can be specified with
+        ``format``, which defaults to ``ps`` (PostScript).
+
+        The encoding to use when writing the intermediate graph
+        definition can be set with ``encoding``. (The default is
+        ``utf-8``, which matches the data in memory and is almost
+        always what you want.)
+
+        Returns the output of the rendering tool as ``bytes``, or
+        raises an exception if an error is encountered.
+        The exception is some form of ``OSError`` or an ``AssertionError``.
 
         There's also the preferred possibility of using:
 
@@ -1815,45 +1869,52 @@ class Dot(Graph):
         which are automatically defined for all the supported formats,
         for example:
 
-          - `create_ps()`
-          - `create_gif()`
-          - `create_dia()`
+          - ``create_ps()``
+          - ``create_gif()``
+          - ``create_dia()``
 
-        If 'prog' is a list, instead of a string,
-        then the first item is expected to be the program name,
-        followed by any optional command-line arguments for it:
+        If ``prog`` is a sequence, instead of a string,
+        then the elements after the first are expected to be
+        command-line arguments to be included in the ``prog``
+        invocation:
 
-            [ 'twopi', '-Tdot', '-s10' ]
+            ('twopi', '-Lg', '-s10')
 
+        @param prog:
 
-        @param prog: either:
+          One of:
 
-          - name of Graphviz executable that
-            can be found in the `$PATH`, or
+          - the name of Graphviz executable that
+            can be found in the ``$PATH``.
 
-          - absolute path to Graphviz executable.
+          - the absolute path to Graphviz executable.
 
-          If you have added Graphviz to the `$PATH` and
+          - a sequence (list, tuple) with the first
+            element being one of the above, and the
+            remaining elements being command-line
+            arguments to use when invoking the executable.
+
+          If you have added Graphviz to the ``$PATH`` and
           use its executables as installed
           (without renaming any of them)
           then their names are:
 
-            - `'dot'`
-            - `'twopi'`
-            - `'neato'`
-            - `'circo'`
-            - `'fdp'`
-            - `'sfdp'`
+            - ``dot``
+            - ``twopi``
+            - ``neato``
+            - ``circo``
+            - ``fdp``
+            - ``sfdp``
 
           On Windows, these have the notorious ".exe" extension that,
           only for the above strings, will be added automatically.
 
-          The `$PATH` is inherited from `os.env['PATH']` and
-          passed to `subprocess.Popen` using the `env` argument.
+          The ``$PATH`` is inherited from ``os.env['PATH']`` and
+          passed to ``subprocess.Popen`` using the `env` argument.
 
-          If you haven't added Graphviz to your `$PATH` on Windows,
+          If you haven't added Graphviz to your ``$PATH`` on Windows,
           then you may want to give the absolute path to the
-          executable (for example, to `dot.exe`) in `prog`.
+          executable (for example, to ``dot.exe``) in ``prog``.
         """
         if prog is None:
             prog = self.prog
@@ -1861,9 +1922,11 @@ class Dot(Graph):
         assert prog is not None
 
         if isinstance(prog, (list, tuple)):
-            prog, args = prog[0], prog[1:]
+            _prog: str = prog[0]
+            args: list[str] = list(prog[1:])
         else:
-            args = []  # type: ignore
+            _prog = str(prog)
+            args = []
 
         # temp file
         with tempfile.TemporaryDirectory(
@@ -1881,33 +1944,33 @@ class Dot(Graph):
                     img_data = img_in.read()
                     img_out.write(img_data)
 
-            arguments = [f"-T{format}"] + args + [fp.name]  # type: ignore
+            arguments = [f"-T{format}"] + args + [fp.name]
 
             try:
                 stdout_data, stderr_data, process = call_graphviz(
-                    program=prog,
+                    program=_prog,
                     arguments=arguments,
                     working_dir=tmp_dir,
                 )
             except OSError as e:
                 if e.errno == errno.ENOENT:
-                    args = list(e.args)  # type: ignore
-                    args[1] = f'"{prog}" not found in path.'  # type: ignore
-                    raise OSError(*args)
+                    errargs: list[str] = list(e.args)
+                    errargs[1] = f'"{_prog}" not found in path.'
+                    raise OSError(*errargs)
                 else:
                     raise  # pragma: no cover
 
         if process.returncode != 0:
             code = process.returncode
             print(
-                f'"{prog}" with args {arguments} returned code: {code}\n\n'
+                f'"{_prog}" with args {arguments} returned code: {code}\n\n'
                 f"stdout, stderr:\n"
                 f" {stdout_data.decode('utf-8', errors='replace')}\n"
                 f" {stderr_data.decode('utf-8', errors='replace')}\n"
             )
 
         assert process.returncode == 0, (
-            f'"{prog}" with args {arguments} '
+            f'"{_prog}" with args {arguments} '
             f"returned code: {process.returncode}"
         )
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -723,13 +723,13 @@ def test_generated_create_write() -> None:
     assert svg == written
 
 
-def test_dot_args() -> None:
+def test_prog_with_args() -> None:
     g = pydot.Dot()
     u = pydot.Node("a")
     g.add_node(u)
     with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
         outfile = os.path.join(tmp_dir, "test.svg")
-        g.write_svg(outfile, prog=["twopi", "-Goverlap=scale"])
+        g.write(outfile, format="svg", prog=["twopi", "-Goverlap=scale"])
         assert os.path.exists(outfile)
 
 


### PR DESCRIPTION
The `prog` parameter to `Dot.create` was type-annotated to take any of a list, tuple, str, or None, but `Dot.write` was only typed to accept a str or None. Since `Dot.write()` passed along its `prog` directly to `self.create()` when generating output, clearly they should accept all of the same types.

Redefined both to accept `list[str] | tuple[str] | str | None`.

Also updated both docstrings with more detail about that parameter in particular, and the parameter definitions in general, plus rewrote single-apostrophe fenced literals to use ReST-appropriate double-apostrophe fencing.

I repurposed a test specifically targeting dot calls with arguments supplied (meaning, using a list or tuple `prog=` argument) so that it calls `.write(..., format="svg", prog=[...])` instead of `.write_svg()`. That way, the now-corrected type annotations actually come into play.

We should probably make an effort to reduce use of the monkeypatched convenience functions in our own tests, and rely more on direct calls to `.write()`, `.create()`, `.get()` and `.set()`, since the convenience functions are currently incompatible with static type checking.

(Looking over the test code again, we're actually pretty good about that. For the most part, generated methods aren't used except in the few tests where we're explicitly _testing_ the generated methods.)