### PR TITLE
Accept Node/Subgraph objects in get_node() and get_edge()

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -958,6 +958,21 @@ class Edge(Common):
 __generate_attribute_methods(Edge, EDGE_ATTRIBUTES)
 
 
+def name_of(obj: Any) -> Any:
+    """Return the name of a `Node`, `Subgraph` or `Cluster`.
+
+    Any other value is returned unchanged, so that names, numbers and
+    `FrozenDict` endpoints keep working as lookup keys.
+
+    Nodes and edges are stored under their name, because `Edge` reduces
+    its endpoints to names on construction. Lookups therefore have to
+    apply the same reduction to find them again.
+    """
+    if isinstance(obj, (Node, Subgraph)):
+        return str(obj.get_name())
+    return obj
+
+
 class Graph(Common):
     """Class representing a graph in Graphviz's dot language.
 
@@ -1215,8 +1230,7 @@ class Graph(Common):
         If nodes are deleted it returns True. If no action
         is taken it returns False.
         """
-        if isinstance(name, Node):
-            name = name.get_name()
+        name = name_of(name)
 
         if name in self.obj_dict["nodes"]:
             if index is not None and index < len(self.obj_dict["nodes"][name]):
@@ -1228,16 +1242,18 @@ class Graph(Common):
 
         return False
 
-    def get_node(self, name: str) -> list[Node]:
+    def get_node(self, name: str | Node) -> list[Node]:
         """Retrieve a node from the graph.
 
-        Given a node's name the corresponding Node
-        instance will be returned.
+        Given a node's name, or a `Node` instance, the corresponding
+        Node instance will be returned.
 
         If one or more nodes exist with that name a list of
         Node instances is returned.
         An empty list is returned otherwise.
         """
+        name = name_of(name)
+
         match = []
 
         if name in self.obj_dict["nodes"]:
@@ -1316,11 +1332,7 @@ class Graph(Common):
         else:
             src, dst = src_or_list, dst
 
-        if isinstance(src, Node):
-            src = src.get_name()
-
-        if isinstance(dst, Node):
-            dst = dst.get_name()
+        src, dst = name_of(src), name_of(dst)
 
         if (src, dst) in self.obj_dict["edges"]:
             if index is not None and index < len(
@@ -1340,16 +1352,19 @@ class Graph(Common):
         Given an edge's source and destination the corresponding
         Edge instance(s) will be returned.
 
+        Endpoints may be given as names or as the `Node`, `Subgraph`
+        or `Cluster` instances that `Edge` itself accepts.
+
         If one or more edges exist with that source and destination
         a list of Edge instances is returned.
         An empty list is returned otherwise.
         """
         if isinstance(src_or_list, (list, tuple)) and dst is None:
-            edge_points = tuple(src_or_list)
-            edge_points_reverse = (edge_points[1], edge_points[0])
+            edge_points = tuple(name_of(ep) for ep in src_or_list)
         else:
-            edge_points = (src_or_list, dst)
-            edge_points_reverse = (dst, src_or_list)
+            edge_points = (name_of(src_or_list), name_of(dst))
+
+        edge_points_reverse = (edge_points[1], edge_points[0])
 
         match = []
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -847,6 +847,61 @@ def test_edge_point_object_cluster() -> None:
     assert g.get_edges()[0].to_string() == "cluster_a -> cluster_b;"
 
 
+def test_get_node_by_object() -> None:
+    g = pydot.Graph("testgraph", graph_type="digraph")
+    n = pydot.Node("a")
+    g.add_node(n)
+    assert [node.get_name() for node in g.get_node(n)] == ["a"]
+    assert [node.get_name() for node in g.get_node("a")] == ["a"]
+
+
+def test_get_edge_by_node_object() -> None:
+    g = pydot.Graph("testgraph", graph_type="digraph")
+    n1, n2 = pydot.Node("n1"), pydot.Node("n2")
+    g.add_node(n1)
+    g.add_node(n2)
+    g.add_edge(pydot.Edge(src=n1, dst=n2))
+    assert [e.to_string() for e in g.get_edge(n1, n2)] == ["n1 -> n2;"]
+
+
+def test_get_edge_by_node_object_list() -> None:
+    g = pydot.Graph("testgraph", graph_type="digraph")
+    n1, n2 = pydot.Node("n1"), pydot.Node("n2")
+    g.add_edge(pydot.Edge(n1, n2))
+    assert [e.to_string() for e in g.get_edge([n1, n2])] == ["n1 -> n2;"]
+
+
+def test_get_edge_by_subgraph_object() -> None:
+    g = pydot.Graph("testgraph", graph_type="digraph")
+    a, b = pydot.Subgraph("a"), pydot.Cluster("b")
+    g.add_edge(pydot.Edge(a, b))
+    assert [e.to_string() for e in g.get_edge(a, b)] == ["a -> cluster_b;"]
+
+
+def test_get_edge_by_object_undirected_reversed() -> None:
+    # An undirected graph matches either orientation, and returns the
+    # edge as it was stored.
+    g = pydot.Graph("testgraph", graph_type="graph")
+    n1, n2 = pydot.Node("n1"), pydot.Node("n2")
+    g.add_edge(pydot.Edge(n1, n2))
+    assert [e.to_string() for e in g.get_edge(n2, n1)] == ["n1 -- n2;"]
+
+
+def test_get_edge_by_name_still_works() -> None:
+    g = pydot.Graph("testgraph", graph_type="digraph")
+    g.add_edge(pydot.Edge("n1", "n2"))
+    assert [e.to_string() for e in g.get_edge("n1", "n2")] == ["n1 -> n2;"]
+    assert g.get_edge("n1", "nope") == []
+
+
+def test_del_edge_by_object_matches_get_edge() -> None:
+    g = pydot.Graph("testgraph", graph_type="digraph")
+    n1, n2 = pydot.Node("n1"), pydot.Node("n2")
+    g.add_edge(pydot.Edge(n1, n2))
+    assert g.del_edge(n1, n2) is True
+    assert g.get_edge(n1, n2) == []
+
+
 def test_graph_from_adjacency_matrix() -> None:
     # Directed graphs use every truthy cell.
     g = pydot.graph_from_adjacency_matrix(


### PR DESCRIPTION
Closes #272

### The problem

`Edge` reduces its endpoints to names on construction, and `add_node` keys nodes by name. The lookups never applied the same reduction, so passing the objects back returned nothing:

```python
import pydot

g = pydot.Dot()
n1 = pydot.Node('n1')
n2 = pydot.Node('n2')
g.add_node(n1)
g.add_node(n2)
g.add_edge(pydot.Edge(src=n1, dst=n2))

print(g.get_edge(n1, n2))  # [] -- expected the edge
print(g.get_node(n1))      # [] -- same cause
```

### The change

`get_node()` and `get_edge()` now resolve `Node`/`Subgraph`/`Cluster` arguments to their names before looking them up.

This is only bringing the getters in line with the deleters: `del_node()` and `del_edge()` already did exactly this, inline. Those inline `isinstance` checks are now the shared `name_of()` helper, so there's one place that defines what an endpoint reduces to.

`Cluster` is a `Subgraph` subclass as of #571, so the isinstance check covers all three types.

### Notes on scope

- Anything that isn't a `Node`/`Subgraph`/`Cluster` is passed through untouched, so names, ints, floats and `FrozenDict` endpoints keep working as keys exactly as before.
- Lookup by name is unchanged, and the multi-element list form of `get_edge()` keeps its existing behaviour.
- No change to what `get_edge()` returns: it still hands back the edge as stored, so a reversed lookup on an undirected graph returns the original orientation. There's a test pinning that.

### Testing

Six tests added, covering lookup by `Node`, by the list form, by `Subgraph`/`Cluster`, the undirected reversed case, that name lookups still work, and that `del_edge` and `get_edge` now agree.

`ruff check`, `ruff format --check` and `mypy` (strict) are clean. I couldn't install Graphviz on this machine, so `TestGraphvizRegressions` and three other tests that shell out to `dot` don't run locally; the rest of the suite passes, and none of it touches the subprocess path.