### PR TITLE
Docs: document rendering a graph in a Jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,7 @@ There are two different DOT strings you can retrieve:
 
 #### Display in a Jupyter notebook
 
-Pass the output of a `create_*` method to the matching IPython display
-class to render the graph below a notebook cell:
+To render the graph below a notebook cell:
 
 ```python
 from IPython.display import SVG
@@ -211,16 +210,13 @@ from IPython.display import SVG
 SVG(graph.create_svg())
 ```
 
-SVG keeps the graph sharp at any zoom level and keeps the text
-selectable. For a bitmap instead, use `Image` with `create_png()`:
+Or, as a bitmap:
 
 ```python
 from IPython.display import Image
 
 Image(graph.create_png())
 ```
-
-Both call Graphviz, so they render the graph as Graphviz lays it out.
 
 #### Convert to a NetworkX graph
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ graph.get_node("b")[0].set_shape("box")
 
 ### 3. Output
 
-Here are three different output options:
+Here are four different output options:
 
 #### Generate an image
 
@@ -199,6 +199,28 @@ There are two different DOT strings you can retrieve:
   # Or, save it as a DOT-file:
   graph.write_dot("output_graphviz.dot")
   ```
+
+#### Display in a Jupyter notebook
+
+Pass the output of a `create_*` method to the matching IPython display
+class to render the graph below a notebook cell:
+
+```python
+from IPython.display import SVG
+
+SVG(graph.create_svg())
+```
+
+SVG keeps the graph sharp at any zoom level and keeps the text
+selectable. For a bitmap instead, use `Image` with `create_png()`:
+
+```python
+from IPython.display import Image
+
+Image(graph.create_png())
+```
+
+Both call Graphviz, so they render the graph as Graphviz lays it out.
 
 #### Convert to a NetworkX graph
 


### PR DESCRIPTION
Closes #286

Adds a short "Display in a Jupyter notebook" subsection under *3. Output* in the README:

```python
from IPython.display import SVG

SVG(graph.create_svg())
```

The `create_*` methods already return exactly what the IPython display classes want, but nothing in the docs said so, so it wasn't discoverable. The section also mentions `Image(graph.create_png())` for the bitmap case, and notes that both go through Graphviz.

Verified the snippets against IPython 9.16 — `SVG()` accepts the `bytes` that `create_svg()` returns, no decode needed.

Deliberately scoped to documenting what already works. #220 asks for a `_repr_svg_` on the graph objects so a bare `graph` renders in a cell; that's a code change and a separate issue, so it isn't touched here.