### PR TITLE
Don't emit a blank line for a suppressed default statement

### DIFF
--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1546,6 +1546,13 @@ class Graph(Common):
                 node_str = node.to_string(
                     indent=indent, indent_level=indent_level + 1
                 )
+
+                # A default-attribute statement that sets no attributes
+                # renders as the empty string. Emitting a newline for it
+                # would leave a blank line behind.
+                if not node_str:
+                    continue
+
                 graph.append(f"{node_str}\n")
 
             elif obj["type"] == "edge":

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1547,9 +1547,7 @@ class Graph(Common):
                     indent=indent, indent_level=indent_level + 1
                 )
 
-                # A default-attribute statement that sets no attributes
-                # renders as the empty string. Emitting a newline for it
-                # would leave a blank line behind.
+                # May be empty, avoid blank line
                 if not node_str:
                     continue
 

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -388,7 +388,7 @@ def test_suppressed_default_stmt_leaves_no_blank_line() -> None:
     g.add_node(pydot.Node("NODE"))
     g.add_node(pydot.Node("EDGE"))
     g.add_edge(pydot.Edge("NODE", "EDGE"))
-    assert g.to_string() == ('digraph testgraph {\n"NODE" -> "EDGE";\n}\n')
+    assert g.to_string() == 'digraph testgraph {\n"NODE" -> "EDGE";\n}\n'
 
 
 def test_default_stmt_with_attributes_still_emitted() -> None:
@@ -396,7 +396,7 @@ def test_default_stmt_with_attributes_still_emitted() -> None:
     g.set_node_defaults(shape="box")
     g.add_node(pydot.Node("a"))
     g.add_node(pydot.Node("node"))
-    assert g.to_string() == ("digraph testgraph {\nnode [shape=box];\na;\n}\n")
+    assert g.to_string() == "digraph testgraph {\nnode [shape=box];\na;\n}\n"
 
 
 def test_dot_graph_type_uppercase() -> None:

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -383,6 +383,22 @@ def test_keyword_node_id_uppercase_to_string_with_attributes() -> None:
     assert g.get_nodes()[0].to_string() == "NODE [shape=box];"
 
 
+def test_suppressed_default_stmt_leaves_no_blank_line() -> None:
+    g = pydot.Dot("testgraph", graph_type="digraph")
+    g.add_node(pydot.Node("NODE"))
+    g.add_node(pydot.Node("EDGE"))
+    g.add_edge(pydot.Edge("NODE", "EDGE"))
+    assert g.to_string() == ('digraph testgraph {\n"NODE" -> "EDGE";\n}\n')
+
+
+def test_default_stmt_with_attributes_still_emitted() -> None:
+    g = pydot.Dot("testgraph", graph_type="digraph")
+    g.set_node_defaults(shape="box")
+    g.add_node(pydot.Node("a"))
+    g.add_node(pydot.Node("node"))
+    assert g.to_string() == ("digraph testgraph {\nnode [shape=box];\na;\n}\n")
+
+
 def test_dot_graph_type_uppercase() -> None:
     g = pydot.Dot("G", graph_type="DIGRAPH")
     assert g.get_type() == "digraph"


### PR DESCRIPTION
Refs #553

### What this is (and isn't)

This is **not** a proposal to change keyword handling. In #553 you were clear that an unquoted keyword passed to `Node()` is a default-attribute statement, that `Node("NODE")` should behave like `Node("node")`, and that `Node('"NODE"')` is how you ask for a literal node — and #554 implemented that. All of that is left exactly as it is, and the two `..._uppercase_...` tests from #554 still pass unmodified.

This only cleans up the leftover whitespace from the suppression path.

### The problem

`Node.to_string()` returns `""` for a default statement that sets no attributes, since bare `node;` is meaningless. `Graph.to_string()` appended a newline for it regardless, so every suppressed statement left a blank line:

```python
g = pydot.Dot("my_graph", graph_type="digraph")
g.add_node(pydot.Node("NODE"))
g.add_node(pydot.Node("EDGE"))
g.add_edge(pydot.Edge("NODE", "EDGE"))
print(repr(g.to_string()))
```

Before:
```
'digraph my_graph {\n\n\n"NODE" -> "EDGE";\n}\n'
```

After:
```
'digraph my_graph {\n"NODE" -> "EDGE";\n}\n'
```

Worth noting the output in the original #553 report is already valid DOT on `main` — #554 fixed that part. These blank lines are the only visible remainder of that example.

### The change

Skip the append when the node renders empty, instead of appending a lone `"\n"`.

A default statement that *does* set attributes is still emitted, and which names count as keywords is untouched. Two tests: one for the blank lines, one pinning that `set_node_defaults()` output still renders.

`ruff check`, `ruff format --check` and `mypy` (strict) are clean. Graphviz isn't installed on this machine, so `TestGraphvizRegressions` doesn't run locally — that suite compares rendered output, and this changes only whitespace between statements, but it's worth a look at CI.

Happy to close this if you'd rather keep #553 as a single thread.