### PR TITLE
Type-checking for our tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,11 +64,12 @@ lint = [
 ]
 types = [
   'mypy',
+  'chardet',
+  'pytest'
 ]
 dev = [
   'pydot[lint]',
   'pydot[types]',
-  'chardet',
 ]
 tests = [
   'pydot[dev]',
@@ -90,7 +91,7 @@ select = ['E', 'F', 'W', 'I', 'UP', 'C4']
 
 [tool.mypy]
 strict = true
-files = "src"
+files = ["src", "test"]
 
 [[tool.mypy.overrides]]
 module = "pydot._vendor.tempfile"

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ commands =
 [testenv:mypy-check]
 extras = types
 commands =
-    mypy
+    mypy {posargs}
 
 # For tox-gh
 [gh]

--- a/src/pydot/__init__.py
+++ b/src/pydot/__init__.py
@@ -16,6 +16,7 @@ _logger.debug("pydot initializing")
 _logger.debug("pydot %s", __version__)
 
 
-from pydot.classes import FrozenDict  # noqa: F401, E402
+from pydot.classes import FrozenDict as FrozenDict  # noqa: E402
 from pydot.core import *  # noqa: F403, E402
-from pydot.exceptions import *  # noqa: E402, F403
+from pydot.exceptions import Error as Error  # noqa: E402
+from pydot.exceptions import PydotException as PydotException  # noqa: E402

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -577,7 +577,7 @@ class Common:
     def __setstate__(self, state: AttributeDict) -> None:
         self.obj_dict = state
 
-    def set_parent_graph(self, parent_graph: Common | None) -> None:
+    def set_parent_graph(self, parent_graph: Graph | None) -> None:
         self.obj_dict["parent_graph"] = parent_graph
 
     def get_parent_graph(self) -> Graph | None:

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -690,7 +690,7 @@ class Node(Common):
 
     def __init__(
         self,
-        name: str = "",
+        name: str | int | float | bool = "",
         obj_dict: AttributeDict | None = None,
         **attrs: Any,
     ) -> None:

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -17,14 +17,15 @@ import sys
 import warnings
 from typing import TYPE_CHECKING, Any, Final, Sequence, Union, cast
 
-if TYPE_CHECKING:
-    # `typing_extensions` is always available in `TYPE_CHECKING` blocks,
-    # even if not  installed
-    from typing_extensions import Self, TypeAlias
-
 import pydot
 from pydot._vendor import tempfile
 from pydot.classes import AttributeDict, EdgeEndpoint, FrozenDict
+
+if TYPE_CHECKING:
+    # `typing_extensions` is always available in `TYPE_CHECKING` blocks,
+    # even if not installed
+    from typing_extensions import Self, TypeAlias
+
 
 _logger = logging.getLogger(__name__)
 _logger.debug("pydot core module initializing")

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -1041,6 +1041,28 @@ class Graph(Common):
     def __str__(self) -> str:
         return self.to_string()
 
+    def __enter__(self) -> Self:
+        """Enter the runtime context for this graph.
+
+        Enables a nested construction style:
+
+            with Dot("A") as dot:
+                with Subgraph("B") as sg:
+                    sg.add_node(Node("N1"))
+                    dot.add_subgraph(sg)
+
+        This is syntactic sugar only with no side effects.
+        """
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Exit the runtime context for this graph.
+
+        Performs no cleanup.
+        Always returns `None`, so exceptions are never suppressed.
+        """
+        return
+
     def get_graph_type(self) -> str | None:
         return self.obj_dict["type"]  # type: ignore
 
@@ -1146,28 +1168,6 @@ class Graph(Common):
         seq: int = self.obj_dict.get("current_child_sequence", 1)
         self.obj_dict["current_child_sequence"] = seq + 1
         return seq
-
-    def __enter__(self) -> Self:
-        """Enter the runtime context for this graph.
-
-        Enables a nested construction style:
-
-            with Dot("A") as dot:
-                with Subgraph("B") as sg:
-                    sg.add_node(Node("N1"))
-                    dot.add_subgraph(sg)
-
-        This is syntactic sugar only with no side effects.
-        """
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Exit the runtime context for this graph.
-
-        Performs no cleanup.
-        Always returns `None`, so exceptions are never suppressed.
-        """
-        return
 
     def add_node(self, graph_node: Node) -> None:
         """Adds a node object to the graph.

--- a/src/pydot/core.py
+++ b/src/pydot/core.py
@@ -720,13 +720,13 @@ class Node(Common):
     def __str__(self) -> str:
         return self.to_string()
 
-    def set_name(self, node_name: str | None) -> None:
+    def set_name(self, node_name: str | int | float | bool) -> None:
         """Set the node's name."""
-        self.obj_dict["name"] = node_name
+        self.obj_dict["name"] = str(node_name)
 
     def get_name(self) -> str:
         """Get the node's name."""
-        return self.obj_dict["name"]  # type: ignore
+        return str(self.obj_dict["name"])
 
     def get_port(self) -> str | None:
         """Get the node's port."""

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 
 import pydot
+import pydot.core
 import pydot.exceptions
 from pydot._vendor import tempfile
 
@@ -59,6 +60,7 @@ def test_boolean_attribute() -> None:
 def test_attribute_with_implicit_value() -> None:
     d = 'digraph {\na -> b[label="hi", decorate];\n}'
     graphs = pydot.graph_from_dot_data(d)
+    assert graphs is not None
     (g,) = graphs
     attrs = g.get_edges()[0].get_attributes()
 
@@ -262,6 +264,7 @@ def test_unicode_ids() -> None:
     assert g.get_edges()[0].get_source() == node1
     assert g.get_edges()[0].get_destination() == node2
     graphs = pydot.graph_from_dot_data(g.to_string())
+    assert graphs is not None
     (g2,) = graphs
 
     assert g2.get_node(node1)[0].get_name() == node1
@@ -310,6 +313,7 @@ def test_graph_simplify() -> None:
 def test_multiple_graphs() -> None:
     graph_data = "graph A { a->b };\ngraph B {c->d}"
     graphs = pydot.graph_from_dot_data(graph_data)
+    assert graphs is not None
     n = len(graphs)
     assert n == 2
     names = [g.get_name() for g in graphs]
@@ -503,7 +507,7 @@ def test_executable_not_found_exception() -> None:
 
 def test_subprocess_bad_exit() -> None:
     script = Path(__file__).parent / "badexit.py"
-    (out, err, proc) = pydot.call_graphviz("python", [script], ".")
+    (out, err, proc) = pydot.call_graphviz("python", [str(script)], ".")
     assert isinstance(out, bytes)
     assert isinstance(err, bytes)
     assert proc.returncode == 1
@@ -512,7 +516,12 @@ def test_subprocess_bad_exit() -> None:
 
 def test_dot_bad_input() -> None:
     class MyDot(pydot.Dot):
-        def to_string(self, indent="", indent_level=0) -> str:
+        def to_string(
+            self,
+            indent: T.Any = "",
+            indent_level: int = 0,
+            inline: bool = True,
+        ) -> str:
             return "graph G { {{[{red=blue}]}}; }"
 
     g = MyDot("G")
@@ -521,8 +530,10 @@ def test_dot_bad_input() -> None:
     assert "returned code: 1" in str(e)
 
 
-def test_dot_bad_exit_with_non_utf8_diagnostics(monkeypatch, capsys) -> None:
-    process = subprocess.CompletedProcess([], returncode=1)
+def test_dot_bad_exit_with_non_utf8_diagnostics(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    process = subprocess.CompletedProcess([], returncode=1)  # type: ignore
     # Ensure non-UTF-8 error output does not cause UnicodeDecodeError
     monkeypatch.setattr(
         pydot.core,
@@ -541,25 +552,25 @@ def test_dot_bad_exit_with_non_utf8_diagnostics(monkeypatch, capsys) -> None:
 def test_graph_add_node_argument_type() -> None:
     g = pydot.Graph("testgraph", graph_type="digraph")
     with pytest.raises(TypeError):
-        g.add_node(1)
+        g.add_node(1)  # type: ignore
     with pytest.raises(TypeError):
-        g.add_node("a")
+        g.add_node("a")  # type: ignore
 
 
 def test_graph_add_edge_argument_type() -> None:
     g = pydot.Graph("testgraph", graph_type="digraph")
     with pytest.raises(TypeError):
-        g.add_edge(1)
+        g.add_edge(1)  # type: ignore
     with pytest.raises(TypeError):
-        g.add_edge("a")
+        g.add_edge("a")  # type: ignore
 
 
 def test_graph_add_subgraph_argument_type() -> None:
     g = pydot.Graph("testgraph", graph_type="digraph")
     with pytest.raises(TypeError):
-        g.add_subgraph(1)
+        g.add_subgraph(1)  # type: ignore
     with pytest.raises(TypeError):
-        g.add_subgraph("a")
+        g.add_subgraph("a")  # type: ignore
 
 
 def test_node_parenting() -> None:
@@ -739,13 +750,13 @@ def test_id_storage_and_lookup() -> None:
 def test_generated_setter_getters() -> None:
     g = pydot.Graph("G", graph_type="graph")
     n = pydot.Node("A")
-    n.set_shape("box")
-    n.set_penwidth(2)
+    n.set_shape("box")  # type: ignore
+    n.set_penwidth(2)  # type: ignore
     g.add_node(n)
 
     nout = g.get_nodes()[0]
-    assert nout.get_shape() == "box"
-    assert nout.get_penwidth() == 2
+    assert nout.get_shape() == "box"  # type: ignore
+    assert nout.get_penwidth() == 2  # type: ignore
 
     expected = "graph G {\nA [shape=box, penwidth=2];\n}\n"
     assert g.to_string() == expected
@@ -754,12 +765,12 @@ def test_generated_setter_getters() -> None:
 def test_generated_create_write() -> None:
     g = pydot.Dot()
     g.add_node(pydot.Node("N"))
-    svg = g.create_svg()
+    svg = g.create_svg()  # type: ignore
     assert isinstance(svg, bytes)
     assert svg.startswith(b"<?xml version")
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:  # type: ignore
         outfile = os.path.join(tmp_dir, "write.svg")
-        g.write_svg(outfile)
+        g.write_svg(outfile)  # type: ignore
         with open(outfile, "rb") as outf:
             written = outf.read()
     assert svg == written
@@ -769,9 +780,9 @@ def test_dot_args() -> None:
     g = pydot.Dot()
     u = pydot.Node("a")
     g.add_node(u)
-    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as tmp_dir:  # type: ignore
         outfile = os.path.join(tmp_dir, "test.svg")
-        g.write_svg(outfile, prog=["twopi", "-Goverlap=scale"])
+        g.write_svg(outfile, prog=["twopi", "-Goverlap=scale"])  # type: ignore
         assert os.path.exists(outfile)
 
 
@@ -975,7 +986,7 @@ def test_version() -> None:
 
 def test_call_graphviz() -> None:
     with pytest.raises(FileNotFoundError):
-        pydot.call_graphviz("__dotnotexist", None, ".")
+        pydot.call_graphviz("__dotnotexist", [], ".")
 
 
 def test_object_cloning(objdict: dict[str, T.Any]) -> None:

--- a/test/test_classes.py
+++ b/test/test_classes.py
@@ -6,13 +6,15 @@
 
 from __future__ import annotations
 
+import typing as T
+
 import pytest
 
 import pydot
 from pydot.classes import FrozenDict
 
 
-def test_FrozenDict_create(objdict):
+def test_FrozenDict_create(objdict: dict[str, T.Any]) -> None:
     fd = FrozenDict(objdict)
     assert isinstance(fd, FrozenDict)
     assert isinstance(fd["attributes"], FrozenDict)
@@ -26,7 +28,7 @@ def test_FrozenDict_create(objdict):
     assert fd == fd2["obj_dict"]["frozen"]
 
 
-def test_FrozenDict_modify(objdict):
+def test_FrozenDict_modify(objdict: dict[str, T.Any]) -> None:
     fd = FrozenDict(objdict)
 
     with pytest.raises(AttributeError):
@@ -51,7 +53,7 @@ def test_FrozenDict_modify(objdict):
         del fd["nodes"]
 
 
-def test_FrozenDict_compare():
+def test_FrozenDict_compare() -> None:
     dict_in = {
         "red": "first",
         "green": "second",
@@ -80,7 +82,7 @@ def test_FrozenDict_repr() -> None:
     )
 
 
-def test_frozendict_deprecation(objdict):
+def test_frozendict_deprecation(objdict: dict[str, T.Any]) -> None:
     with pytest.warns(DeprecationWarning):
         fd = pydot.frozendict(objdict)
 

--- a/test/test_context_managers.py
+++ b/test/test_context_managers.py
@@ -11,7 +11,7 @@ import pytest
 import pydot
 
 
-def test_context_manager_returns_exact_instance():
+def test_context_manager_returns_exact_instance() -> None:
     g_orig = pydot.Graph("G")
     with g_orig as g_ctx:
         assert g_orig is g_ctx
@@ -23,14 +23,14 @@ def test_context_manager_returns_exact_instance():
         assert g_orig is g_ctx
 
 
-def test_context_manager_empty_block():
+def test_context_manager_empty_block() -> None:
     with pydot.Graph("G") as g:
         pass
     assert g.get_name() == "G"
     assert len(g.get_nodes()) == 0
 
 
-def test_context_manager_dot():
+def test_context_manager_dot() -> None:
     with pydot.Dot(graph_name="main", graph_type="digraph") as dot:
         assert isinstance(dot, pydot.Dot)
 
@@ -49,7 +49,7 @@ def test_context_manager_dot():
     assert dot.get_nodes()[1].get_name() == "B"
 
 
-def test_context_manager_graph():
+def test_context_manager_graph() -> None:
     with pydot.Graph(graph_name="G") as g:
         assert isinstance(g, pydot.Graph)
         g.add_node(pydot.Node("B"))
@@ -58,7 +58,7 @@ def test_context_manager_graph():
     assert len(g.get_nodes()) == 1
 
 
-def test_context_manager_subgraph():
+def test_context_manager_subgraph() -> None:
     with pydot.Subgraph(graph_name="sub") as sub:
         assert isinstance(sub, pydot.Subgraph)
         sub.add_node(pydot.Node("C"))
@@ -67,7 +67,7 @@ def test_context_manager_subgraph():
     assert len(sub.get_nodes()) == 1
 
 
-def test_context_manager_cluster():
+def test_context_manager_cluster() -> None:
     with pydot.Cluster(graph_name="my_cluster") as cluster:
         assert isinstance(cluster, pydot.Cluster)
         cluster.add_node(pydot.Node("D"))
@@ -77,7 +77,7 @@ def test_context_manager_cluster():
     assert len(cluster.get_nodes()) == 1
 
 
-def test_context_manager_nested_mixed():
+def test_context_manager_nested_mixed() -> None:
     dot = pydot.Dot("my_graph", graph_type="digraph")
 
     with pydot.Cluster("my_cluster") as cluster:
@@ -111,7 +111,7 @@ def test_context_manager_nested_mixed():
     assert deep_obj.get_nodes()[0].get_name() == "D"
 
 
-def test_context_manager_exception_propagation():
+def test_context_manager_exception_propagation() -> None:
     # Context manager should not swallow exceptions
     with pytest.raises(ValueError, match="test error"):
         with pydot.Dot() as dot:

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -11,7 +11,7 @@ import textwrap
 import pyparsing as pp
 import pytest
 
-from pydot import dot_parser
+from pydot import core, dot_parser
 from pydot.dot_parser import HTML, GraphParser
 
 
@@ -39,6 +39,7 @@ def test_edge_subgraph_anon() -> None:
     res = parser.parse_string("""a -- { b; c; }""")
     assert len(res) == 1
     edge = res[0]
+    assert isinstance(edge, core.Edge)
     expected = textwrap.dedent("""
         a -- {
         b;
@@ -53,6 +54,7 @@ def test_edge_subgraph_explicit() -> None:
     res = parser.parse_string("""a -- subgraph XY { b; c; }""")
     assert len(res) == 1
     edge = res[0]
+    assert isinstance(edge, core.Edge)
     expected = textwrap.dedent("""
         a -- subgraph XY {
         b;
@@ -89,7 +91,9 @@ def test_keyword_case_insensitive_graph_type() -> None:
         ("Digraph G { a -> b }", "digraph"),
         ("Graph G { a -- b }", "graph"),
     ]:
-        (g,) = dot_parser.parse_dot_data(src)
+        graphs = dot_parser.parse_dot_data(src)
+        assert graphs is not None
+        g = graphs[0]
         assert g.get_type() == expected_type, src
 
 
@@ -101,7 +105,9 @@ def test_keyword_case_insensitive_strict() -> None:
         "Strict Digraph G { a -> b }",
         "strict GRAPH G { a -- b }",
     ]:
-        (g,) = dot_parser.parse_dot_data(src)
+        graphs = dot_parser.parse_dot_data(src)
+        assert graphs is not None
+        g = graphs[0]
         assert g.get_strict(), src
 
 
@@ -116,7 +122,9 @@ def test_keyword_case_insensitive_node_edge_defaults() -> None:
             f"digraph G {{ {node_kw} [color=red]; {edge_kw}"
             " [style=dashed]; a -> b }}"
         )
-        (g,) = dot_parser.parse_dot_data(src)
+        graphs = dot_parser.parse_dot_data(src)
+        assert graphs is not None
+        g = graphs[0]
         assert g.get_node_defaults() == [{"color": "red"}], src
         assert g.get_edge_defaults() == [{"style": "dashed"}], src
 
@@ -125,7 +133,9 @@ def test_keyword_case_insensitive_subgraph() -> None:
     """SUBGRAPH keyword is case-insensitive."""
     for kw in ["subgraph", "SUBGRAPH", "Subgraph"]:
         src = f"digraph G {{ {kw} SUB {{ a; b; }} }}"
-        (g,) = dot_parser.parse_dot_data(src)
+        graphs = dot_parser.parse_dot_data(src)
+        assert graphs is not None
+        g = graphs[0]
         subs = g.get_subgraphs()
         assert len(subs) == 1, src
         assert subs[0].get_name() == "SUB", src
@@ -207,7 +217,7 @@ def test_plus_concatenation() -> None:
     assert edge.get("arrows") == '"both"'
 
 
-def test_bad_parse_brace(capsys) -> None:
+def test_bad_parse_brace(capsys: pytest.CaptureFixture[str]) -> None:
     src = textwrap.dedent(r"""
         graph G {
             a -- b;
@@ -224,7 +234,7 @@ def test_bad_parse_brace(capsys) -> None:
     assert captured.out.strip() == expected
 
 
-def test_bad_parse_bracket(capsys) -> None:
+def test_bad_parse_bracket(capsys: pytest.CaptureFixture[str]) -> None:
     src = textwrap.dedent(r"""
         graph G {
             a -- b;

--- a/test/test_pydot.py
+++ b/test/test_pydot.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import functools
 import os
 import sys
+import typing as T
 from collections.abc import Generator
 from hashlib import sha256
 
@@ -111,7 +112,7 @@ class Renderer:
                 g.create(prog=TEST_PROGRAM, format="jpe", encoding=encoding)
             )
         src = "\n".join(g.to_string() for g in c)
-        return PydotRenderResult(jpe_data, src)
+        return PydotRenderResult(T.cast("bytes", jpe_data), src)
 
 
 def _load_test_cases(casedir: str) -> Generator[tuple[str, str, str]]:


### PR DESCRIPTION
A whole bunch of commits in service of the final one: Add the
`test/` directory to the list of locations MyPy will type-check.

To make that work, a large number of adjustments had to be made to the test scripts, and a few to the core classes as well. Some of the core fixes represent API changes. Like:

* The `pydot.core.Node()` constructor accepts `int`, `float,` and `bool` as its `name=` argument, in addition to `str`. Whatever type the parameter is, it stores it in `obj_dict` as `str(name)`. (The latter was existing code.) 
    Necessary because some of our own tests are calling `pydot.Node(1)` or `pydot.Node(True)` and expecting that to work.
* `pydot.core.Node.set_name()` now also accepts `int`, `float`, and `bool` in addition to `str`, and does NOT accept `None`. For parity with the constructor, it now also stores `str(node_name)` in the `obj_dict`.
* `pydot.core.Common.set_parent_graph()` used to accept `Common` as its argument, a consequence of `Graph` not being defined yet. Now that we're using `from __future__ import annotations`, that's not a problem and it can be updated to the correct `Graph`.

Other changes are non-API. 

* Lots of typing fixes in the tests. All of the calls to generated methods have to be `# type: ignore`d until we solve the problem of dynamic API not being properly type-checkable.
* Some tweaks to the code layout in `pydot.core.Graph` and the module imports (no functional changes)
* Use aliased explicit imports (`from pydot.exceptions import Error as Error`) in `__init__`, as a supported method of evading Ruff's "F401 unused-import".