### PR TITLE
Make xfail markers strict so fixed defects are reported

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,6 +11,7 @@ tag-format=v{version}
 
 [tool:pytest]
 testpaths = test
+xfail_strict = true
 
 [tox:tox]
 min_version = 4.6.3


### PR DESCRIPTION
Without `xfail_strict`, pytest treats an xfail that starts passing as `XPASS`
and keeps the suite green. That has two consequences for the five markers in
`test_api.py`:

- when one of those defects is fixed, nothing says so, and the marker stays
- and after that the test can no longer fail at all: if the fix regresses, a
  failure is exactly what the marker expects, so it is reported as `xfailed`
  and the suite is green again

So a non-strict xfail stops protecting anything once its defect is fixed.

```
                     defect present      defect fixed
without strict       xfailed  (green)    xpassed  (green)
with strict          xfailed  (green)    failed   (red)
```

With `xfail_strict = true` the second column becomes a CI failure in the PR that
fixed it, which is when removing the marker is cheapest.

Safe to turn on now: `pytest -q -rX` reports `303 passed, 5 xfailed` with no
`xpassed`, so all five defects are still present and the suite stays green.

Added to the existing `[tool:pytest]` section in `setup.cfg` rather than
starting a new one in `pyproject.toml`, since that is where the pytest config
already lives.